### PR TITLE
 feat: 홈 화면 데이터 도메인 통합 및 네비게이션 로직 고도화

### DIFF
--- a/Playproof/src/App.tsx
+++ b/Playproof/src/App.tsx
@@ -8,6 +8,7 @@ const LoginPage = lazy(() => import('@/pages/auth/LoginPage'));
 const SignupPage = lazy(() => import('@/pages/auth/SignupPage'));
 const SignupGameSelectPage = lazy(() => import('@/pages/auth/SignupGameSelectPage'));
 const SignupGameInfoPage = lazy(() => import('@/pages/auth/SignupGameInfoPage'));
+const SignupUsernamePage = lazy(() => import('@/pages/auth/SignupUsernamePage'));
 const HomePage = lazy(() => import('@/pages/home/HomePage'));
 const MatchingPage = lazy(() => import('@/pages/matching/MatchingPage'));
 const AzitPage = lazy(() => import('@/pages/azit/AzitPage'));
@@ -47,6 +48,7 @@ function App() {
                 <Route path="/landing" element={<LandingPage />} />
                 <Route path="/signup" element={<SignupPage />} />
                 <Route path="/login" element={<LoginPage />} />
+                <Route path="/signup/username" element={<SignupUsernamePage />} />
                 
                 {/* Game Select */}
                 <Route path="/gameselect" element={<SignupGameSelectPage />} />

--- a/Playproof/src/App.tsx
+++ b/Playproof/src/App.tsx
@@ -1,6 +1,6 @@
 // src/App.tsx
-import React, { Suspense, lazy } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import React, { Suspense, lazy, useEffect } from 'react';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 
 // Lazy Load Pages
 const LandingPage = lazy(() => import('@/pages/auth/LandingPage'));
@@ -9,6 +9,7 @@ const SignupPage = lazy(() => import('@/pages/auth/SignupPage'));
 const SignupGameSelectPage = lazy(() => import('@/pages/auth/SignupGameSelectPage'));
 const SignupGameInfoPage = lazy(() => import('@/pages/auth/SignupGameInfoPage'));
 const SignupUsernamePage = lazy(() => import('@/pages/auth/SignupUsernamePage'));
+const FindPasswordPage = lazy(() => import('@/pages/auth/FindPasswordPage'));
 const HomePage = lazy(() => import('@/pages/home/HomePage'));
 const MatchingPage = lazy(() => import('@/pages/matching/MatchingPage'));
 const AzitPage = lazy(() => import('@/pages/azit/AzitPage'));
@@ -37,6 +38,7 @@ const LoadingFallback = () => (
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <ToastProvider>
         <UserProfileProvider>
           <MatchingDetailProvider>
@@ -49,6 +51,7 @@ function App() {
                 <Route path="/signup" element={<SignupPage />} />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/signup/username" element={<SignupUsernamePage />} />
+                <Route path="/find-password" element={<FindPasswordPage />} />
                 
                 {/* Game Select */}
                 <Route path="/gameselect" element={<SignupGameSelectPage />} />
@@ -84,5 +87,13 @@ function App() {
     </BrowserRouter>
   );
 }
+
+const ScrollToTop = () => {
+  const location = useLocation();
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' as ScrollBehavior });
+  }, [location.pathname, location.search]);
+  return null;
+};
 
 export default App;

--- a/Playproof/src/components/auth/SignupCompleteModal.tsx
+++ b/Playproof/src/components/auth/SignupCompleteModal.tsx
@@ -7,7 +7,7 @@ type Props = {
   onClose: () => void;
 };
 
-const AUTO_CLOSE_MS = 1800;
+const AUTO_CLOSE_MS = 5000;
 
 export function SignupCompleteModal({ open, username, onClose }: Props) {
   // ✅ 자동 닫힘 (확인 버튼 없이 토스트처럼 사라지게)

--- a/Playproof/src/components/auth/StepDots.tsx
+++ b/Playproof/src/components/auth/StepDots.tsx
@@ -13,7 +13,7 @@ const Dot = ({ active, label }: { active?: boolean; label: string }) => {
     <div
       className={cn(
         "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold",
-        active ? "bg-black text-white" : "bg-[#D9D9D9] text-white"
+        active ? "bg-[#1533B6] text-white" : "bg-[#D9D9D9] text-white"
       )}
     >
       {label}

--- a/Playproof/src/components/common/Navbar.tsx
+++ b/Playproof/src/components/common/Navbar.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Bell, Settings, User, ChevronDown, CreditCard, ShoppingCart, LogOut, FileText, Gamepad2 } from 'lucide-react';
 import { NotificationDropdown } from '@/features/notification/components';
 import { NAV_LINKS } from '@/constants/navigation';
+import { Button } from '@/components/ui/Button';
 
 interface NavbarProps {
   isProUser?: boolean;
@@ -32,6 +33,13 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
   }, []);
 
   const isActive = (path: string) => location.pathname.startsWith(path);
+  const isAuthPage =
+    location.pathname === '/' ||
+    location.pathname.startsWith('/landing') ||
+    location.pathname.startsWith('/login') ||
+    location.pathname.startsWith('/signup') ||
+    location.pathname.startsWith('/gameselect') ||
+    location.pathname.startsWith('/gameinfo');
 
   // ✨ 페이지별 드롭다운 메뉴 내용을 결정하는 함수
   const renderProfileMenu = () => {
@@ -130,6 +138,16 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
         
         {/* 2. 우측 컨트롤 */}
         <div className="flex items-center gap-4">
+          {isAuthPage ? (
+            <Button
+              variant="primary"
+              className="h-9 rounded-md px-4 text-sm"
+              onClick={() => navigate('/login')}
+            >
+              로그인
+            </Button>
+          ) : (
+            <>
           {onTogglePro && (
             <button 
               onClick={onTogglePro} 
@@ -196,6 +214,8 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
           </div>
 
           <Settings className="w-5 h-5 text-gray-500 cursor-pointer hover:text-black transition-colors" />
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/Playproof/src/components/common/Navbar.tsx
+++ b/Playproof/src/components/common/Navbar.tsx
@@ -5,6 +5,7 @@ import { Bell, Settings, User, ChevronDown, CreditCard, ShoppingCart, LogOut, Fi
 import { NotificationDropdown } from '@/features/notification/components';
 import { NAV_LINKS } from '@/constants/navigation';
 import { Button } from '@/components/ui/Button';
+import { useAuthStore } from '@/store/authStore';
 
 interface NavbarProps {
   isProUser?: boolean;
@@ -14,6 +15,8 @@ interface NavbarProps {
 export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const authNickname = useAuthStore((s) => s.nickname);
+  const displayName = authNickname ?? "사용자";
   
   const [isNotiOpen, setIsNotiOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
@@ -169,7 +172,7 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
               </div>
               
               {/* 닉네임 & 뱃지 */}
-              <span className="font-bold text-sm text-gray-800">플루</span>
+              <span className="font-bold text-sm text-gray-800">{displayName}</span>
               <span className="bg-zinc-200 text-[10px] font-bold px-1.5 py-0.5 rounded text-gray-600">Pro</span>
 
               {/* 스크롤 버튼 (화살표) */}
@@ -187,7 +190,7 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
                       <User size={20} />
                     </div>
                     <div>
-                      <p className="text-sm font-bold text-gray-900">플루</p>
+                      <p className="text-sm font-bold text-gray-900">{displayName}</p>
                       <p className="text-xs text-gray-500">playproof12@gmail.com</p>
                     </div>
                   </div>

--- a/Playproof/src/components/layout/AppLayout.tsx
+++ b/Playproof/src/components/layout/AppLayout.tsx
@@ -1,18 +1,15 @@
-import { Outlet } from "react-router-dom";
-import { SignupCompleteModal } from "@/components/auth/SignupCompleteModal";
-import { useSignupCompleteModal } from "@/features/auth/signup/hooks/useSignupCompleteModal";
+import type { ReactNode } from "react";
+import { Navbar } from "@/components/common/Navbar";
 
-export default function AppLayout() {
-  const { open, username, close } = useSignupCompleteModal();
+type AppLayoutProps = {
+  children: ReactNode;
+};
 
+export const AppLayout = ({ children }: AppLayoutProps) => {
   return (
-    <div className="min-h-screen bg-white text-black">
-      {/* TODO: App 영역 Navbar가 있으면 여기 */}
-      {/* <Navbar /> */}
-
-      <Outlet />
-
-      <SignupCompleteModal open={open} username={username} onClose={close} />
+    <div className="min-h-screen bg-white text-black relative">
+      <Navbar />
+      {children}
     </div>
   );
-}
+};

--- a/Playproof/src/components/ui/Button.tsx
+++ b/Playproof/src/components/ui/Button.tsx
@@ -42,7 +42,7 @@ export function Button({
     "bg-[#C6C6C6] text-white cursor-not-allowed pointer-events-none";
 
   const variants: Record<ButtonVariant, string> = {
-    primary: "bg-black text-white hover:bg-black/90",
+    primary: "bg-[#1533B6] text-white hover:bg-[#122CA3]",
     secondary: "bg-[#C6C6C6] text-white hover:bg-[#B5B5B5]",
     outline: "bg-white text-black border border-black hover:bg-black hover:text-white",
     blue: "bg-[#4562D6] text-white hover:brightness-95",

--- a/Playproof/src/components/ui/OnboardingIndicator.tsx
+++ b/Playproof/src/components/ui/OnboardingIndicator.tsx
@@ -4,14 +4,17 @@ import { useEffect, useMemo, useRef, useState } from "react";
 type Props = {
 	total: number;
 	initialActive?: number;
-	/** 진한 바 길이 수정 */
+	/** 진한 바 길이 */
 	activeWidth?: number;
+	/** 자동 전환 간격(ms). 0이면 자동 전환 없음 */
+	autoMs?: number;
 };
 
 export const OnboardingIndicator = ({
 	total,
 	initialActive = 0,
 	activeWidth = 183,
+	autoMs = 3500,
 }: Props) => {
 	const safeTotal = Math.max(1, total);
 	const [active, setActive] = useState(
@@ -21,7 +24,6 @@ export const OnboardingIndicator = ({
 	const trackRef = useRef<HTMLButtonElement | null>(null);
 	const [trackPx, setTrackPx] = useState<number>(0);
 
-	// 실제 트랙 너비를 측정해서 상태로 보관
 	useEffect(() => {
 		const el = trackRef.current;
 		if (!el) return;
@@ -34,6 +36,14 @@ export const OnboardingIndicator = ({
 
 		return () => ro.disconnect();
 	}, []);
+
+	useEffect(() => {
+		if (autoMs <= 0 || safeTotal <= 1) return;
+		const id = window.setInterval(() => {
+			setActive((prev) => (prev + 1) % safeTotal);
+		}, autoMs);
+		return () => window.clearInterval(id);
+	}, [autoMs, safeTotal]);
 
 	const stepGap = useMemo(() => {
 		if (safeTotal <= 1) return 0;
@@ -51,11 +61,10 @@ export const OnboardingIndicator = ({
 		const x = Math.min(Math.max(clientX - rect.left, 0), rect.width);
 
 		if (safeTotal === 1) {
-		setActive(0);
-		return;
+			setActive(0);
+			return;
 		}
 
-		// 진한 바의 시작점을 기준으로 단계 선택 (트랙 내부로 clamp)
 		const usable = Math.max(0, rect.width - activeWidth);
 		const startX = Math.min(Math.max(x - activeWidth / 2, 0), usable);
 		const gap = usable / (safeTotal - 1);
@@ -66,7 +75,6 @@ export const OnboardingIndicator = ({
 
 	return (
 		<div className="flex items-center justify-center">
-		{/* 트랙은 실제 UI 너비를 원하는 값으로 조절 */}
 			<button
 				ref={trackRef}
 				type="button"
@@ -74,21 +82,19 @@ export const OnboardingIndicator = ({
 				onClick={(e) => setActiveByClientX(e.clientX)}
 				onKeyDown={(e) => {
 					if (e.key === "ArrowLeft") setActive((v) => Math.max(0, v - 1));
-					if (e.key === "ArrowRight") setActive((v) => Math.min(safeTotal - 1, v + 1));
+					if (e.key === "ArrowRight")
+						setActive((v) => Math.min(safeTotal - 1, v + 1));
 					if (e.key === "Home") setActive(0);
 					if (e.key === "End") setActive(safeTotal - 1);
 				}}
-				/* 긴 연한 바 길이 수정 */
-				className="relative h-[18px] w-[549px] focus:outline-none"
+				className="relative h-[4px] w-[549px] pr-[366px] focus:outline-none"
 			>
-				{/* 긴 연한 바 */}
 				<span
-					className="absolute left-0 top-1/2 h-[3px] w-full -translate-y-1/2 rounded-full bg-[#E4E4E7]"
+					className="absolute inset-0 rounded-[4px] bg-[#E4E4E7]"
 					aria-hidden
 				/>
-				{/* 짧은 진한 바 */}
 				<span
-					className="absolute left-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-[#7a7a7a] transition-transform duration-300"
+					className="absolute left-0 top-1/2 h-[4px] -translate-y-1/2 rounded-[4px] bg-[#1533B6] transition-transform duration-300"
 					style={{
 						width: activeWidth,
 						transform: `translateX(${offset}px)`,
@@ -96,6 +102,9 @@ export const OnboardingIndicator = ({
 					aria-hidden
 				/>
 			</button>
+			<div className="sr-only" aria-live="polite">
+				{`slide ${active + 1} of ${safeTotal}`}
+			</div>
 		</div>
 	);
 };

--- a/Playproof/src/features/auth/find-password/components/CompleteStep.tsx
+++ b/Playproof/src/features/auth/find-password/components/CompleteStep.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@/components/ui/Button";
+import { useNavigate } from "react-router-dom";
+
+export const CompleteStep = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center text-center gap-10 py-4">
+      <div className="w-20 h-20 rounded-full border-[3px] border-[#1533B6] flex items-center justify-center">
+        <svg className="w-10 h-10 text-[#1533B6]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+
+      <div>
+        <h2 className="text-2xl font-bold mb-2">비밀번호 변경이 완료됐습니다.</h2>
+        <p className="text-gray-500 text-sm">새 비밀번호로 로그인해 주세요.</p>
+      </div>
+
+      <Button fullWidth onClick={() => navigate("/login")}>
+        로그인하러 가기
+      </Button>
+    </div>
+  );
+};

--- a/Playproof/src/features/auth/find-password/components/NewPasswordStep.tsx
+++ b/Playproof/src/features/auth/find-password/components/NewPasswordStep.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+import { PASSWORD_REGEX } from "@/features/auth/constants/regex";
+
+export const NewPasswordStep = ({ onNext }: { onNext: () => void }) => {
+  const [password, setPassword] = useState("");
+  const isError = password.length > 0 && !PASSWORD_REGEX.test(password);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <h2 className="text-2xl font-bold mb-2">새 비밀번호를 입력해 주세요</h2>
+        <p className="text-gray-500 text-sm">영문, 숫자 포함 8글자 이상 입력해주세요.</p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Input
+          type="password"
+          label="비밀번호"
+          placeholder="새 비밀번호를 입력해주세요."
+          variant="light"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={isError ? "영문, 숫자 포함 8글자 이상이어야 합니다." : ""}
+        />
+        <p className="text-[11px] text-gray-400 leading-tight">
+          쉬운 비밀번호, 다른 사이트에서 사용한 비밀번호, 도용된 비밀번호는 피해 주세요.
+        </p>
+      </div>
+
+      <Button
+        fullWidth
+        disabled={!password || isError}
+        onClick={onNext}
+      >
+        확인
+      </Button>
+    </div>
+  );
+};

--- a/Playproof/src/features/auth/find-password/components/PhoneStep.tsx
+++ b/Playproof/src/features/auth/find-password/components/PhoneStep.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+
+interface PhoneStepProps {
+  onNext: (data: { name: string; phone: string }) => void;
+}
+
+export const PhoneStep = ({ onNext }: PhoneStepProps) => {
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/\D/g, "").slice(0, 11);
+    setPhone(value);
+  };
+
+  const isFormValid = name.length > 0 && phone.length === 11;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold mb-2">비밀번호 찾기</h2>
+        <p className="text-gray-500 text-sm">전화번호를 입력해 주세요.</p>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <Input
+          label="전화번호"
+          placeholder="전화번호를 -없이 입력해주세요."
+          variant="light"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          maxLength={11}
+          autoComplete="tel"
+          value={phone}
+          onChange={handlePhoneChange}
+        />
+        {phone.length === 11 ? (
+          <Input
+            label="이름"
+            placeholder="이름을 입력해주세요."
+            variant="light"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        ) : null}
+      </div>
+
+      <Button
+        fullWidth
+        disabled={!isFormValid}
+        onClick={() => onNext({ name, phone })}
+      >
+        다음
+      </Button>
+    </div>
+  );
+};

--- a/Playproof/src/features/auth/find-password/components/VerificationStep.tsx
+++ b/Playproof/src/features/auth/find-password/components/VerificationStep.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect } from "react";
+import { Button } from "@/components/ui/Button";
+import { usePhoneVerification } from "@/features/auth/signup/hooks/usePhoneVerification";
+
+interface VerificationStepProps {
+  phone: string;
+  onNext: () => void;
+}
+
+export const VerificationStep = ({ onNext }: VerificationStepProps) => {
+  const { uiProps, verifyState } = usePhoneVerification();
+
+  // 진입 시 자동 SMS 발송
+  useEffect(() => {
+    uiProps.onRequestSms();
+  }, [uiProps]);
+
+  return (
+    <div className="flex flex-col gap-8 text-center">
+      <div>
+        <h2 className="text-2xl font-bold mb-2">인증문자를 발송했어요</h2>
+        <p className="text-gray-500 text-sm">인증번호를 입력해 주세요.</p>
+      </div>
+
+      <div className="relative flex flex-col items-center gap-4">
+        {/* OTP 스타일 입력 UI */}
+        <div className="flex gap-2">
+          {[...Array(6)].map((_, i) => (
+            <div
+              key={i}
+              className={`w-12 h-14 border rounded-lg flex items-center justify-center text-xl font-bold bg-white 
+                ${uiProps.code[i] ? "border-blue-600" : "border-gray-200"}`}
+            >
+              {uiProps.code[i] || ""}
+            </div>
+          ))}
+        </div>
+        
+        {/* 실제 입력을 받는 hidden input */}
+        <input
+          type="text"
+          className="absolute inset-0 opacity-0 cursor-default"
+          value={uiProps.code}
+          onChange={(e) => uiProps.onCodeChange(e.target.value)}
+          maxLength={6}
+          autoFocus
+        />
+
+        <div className="flex justify-between w-full px-1 text-xs">
+          <span className="text-red-500 font-medium">남은 시간 {uiProps.codeTimeLabel}</span>
+          <button 
+            type="button" 
+            onClick={uiProps.onRequestSms} 
+            className="text-gray-400 underline"
+          >
+            재전송
+          </button>
+        </div>
+      </div>
+
+      <Button
+        fullWidth
+        disabled={uiProps.code.length !== 6}
+        onClick={async () => {
+          await uiProps.onVerifyCode();
+          if (verifyState === "success" || uiProps.code === "123456") onNext(); // 테스트용 조건
+        }}
+      >
+        다음
+      </Button>
+    </div>
+  );
+};

--- a/Playproof/src/features/auth/gameInfoPage/components/SignupGameInfoForm.tsx
+++ b/Playproof/src/features/auth/gameInfoPage/components/SignupGameInfoForm.tsx
@@ -58,21 +58,34 @@ export function SignupGameInfoForm() {
 
             <div className="space-y-2">
               <p className="text-sm font-semibold text-gray-900">플레이 스타일</p>
-              <select
-                className={cn(
-                  "h-12 w-full rounded-lg border bg-white px-4 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-black/20",
-                  showErrors && errors.playStyle ? "border-red-400" : "border-gray-200"
-                )}
-                value={playStyle}
-                onChange={(e) => onChangePlayStyle(e.target.value)}
-              >
-                <option value="">스타일 선택</option>
-                {playStyleOptions.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
+              <div className="flex w-full gap-4">
+                <Button
+                  type="button"
+                  variant={playStyle === "실력 중심" ? "primary" : "outline"}
+                  fullWidth
+                  className={cn(
+                    "h-12",
+                    playStyle !== "실력 중심" &&
+                      "border-[#1533B6] text-[#1533B6] hover:bg-[#1533B6] hover:text-white"
+                  )}
+                  onClick={() => onChangePlayStyle("실력 중심")}
+                >
+                  실력 중심
+                </Button>
+                <Button
+                  type="button"
+                  variant={playStyle === "매너 중심" ? "primary" : "outline"}
+                  fullWidth
+                  className={cn(
+                    "h-12",
+                    playStyle !== "매너 중심" &&
+                      "border-[#1533B6] text-[#1533B6] hover:bg-[#1533B6] hover:text-white"
+                  )}
+                  onClick={() => onChangePlayStyle("매너 중심")}
+                >
+                  매너 중심
+                </Button>
+              </div>
               {showErrors && errors.playStyle ? (
                 <p className="text-xs text-red-500">{errors.playStyle}</p>
               ) : null}
@@ -125,18 +138,20 @@ export function SignupGameInfoForm() {
             </div>
           </div>
 
-          <div className="pt-2">
-            <Button
-              type="button"
-              variant="secondary"
-              fullWidth
-              className="h-12"
-              disabled={!canSubmit || isPending}
-              onClick={onSubmit}
-            >
-              {isPending ? "가입 처리 중..." : "가입하기"}
-            </Button>
-          </div>
+          {canSubmit ? (
+            <div className="pt-2">
+              <Button
+                type="button"
+                variant="primary"
+                fullWidth
+                className="h-12"
+                disabled={isPending}
+                onClick={onSubmit}
+              >
+                {isPending ? "가입 처리 중..." : "가입하기"}
+              </Button>
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="mx-auto w-full max-w-[520px] space-y-8">
@@ -168,9 +183,13 @@ export function SignupGameInfoForm() {
             <div className="flex w-full gap-4">
               <Button
                 type="button"
-                variant="primary"
+                variant={playStyle === "실력 중심" ? "primary" : "outline"}
                 fullWidth
-                className="h-12"
+                className={cn(
+                  "h-12",
+                  playStyle !== "실력 중심" &&
+                    "border-[#1533B6] text-[#1533B6] hover:bg-[#1533B6] hover:text-white"
+                )}
                 onClick={() => onSelectManualPlayStyle("실력 중심")}
               >
                 실력 중심
@@ -178,9 +197,13 @@ export function SignupGameInfoForm() {
 
               <Button
                 type="button"
-                variant="outline"
+                variant={playStyle === "매너 중심" ? "primary" : "outline"}
                 fullWidth
-                className="h-12"
+                className={cn(
+                  "h-12",
+                  playStyle !== "매너 중심" &&
+                    "border-[#1533B6] text-[#1533B6] hover:bg-[#1533B6] hover:text-white"
+                )}
                 onClick={() => onSelectManualPlayStyle("매너 중심")}
               >
                 매너 중심
@@ -192,18 +215,20 @@ export function SignupGameInfoForm() {
             ) : null}
           </div>
 
-          <div className="pt-2">
-            <Button
-              type="button"
-              variant="secondary"
-              fullWidth
-              className="h-12"
-              disabled={!canSubmit || isPending}
-              onClick={onSubmit}
-            >
-              {isPending ? "가입 처리 중..." : "가입하기"}
-            </Button>
-          </div>
+          {canSubmit ? (
+            <div className="pt-2">
+              <Button
+                type="button"
+                variant="primary"
+                fullWidth
+                className="h-12"
+                disabled={isPending}
+                onClick={onSubmit}
+              >
+                {isPending ? "가입 처리 중..." : "가입하기"}
+              </Button>
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/Playproof/src/features/auth/gameInfoPage/components/SignupGameInfoForm.tsx
+++ b/Playproof/src/features/auth/gameInfoPage/components/SignupGameInfoForm.tsx
@@ -15,7 +15,6 @@ export function SignupGameInfoForm() {
     playStyle,
     tier,
     position,
-    playStyleOptions,
     tierOptions,
     positionOptions,
     onChangePlayStyle,

--- a/Playproof/src/features/auth/gameSelectPage/components/GameSelectGrid.tsx
+++ b/Playproof/src/features/auth/gameSelectPage/components/GameSelectGrid.tsx
@@ -19,10 +19,10 @@ export function GameSelectGrid({ games, selectedId, onSelect }: Props) {
             type="button"
             onClick={() => onSelect(g.id)}
             className={cn(
-              "h-12 w-full rounded-md border text-xs font-medium transition-colors",
+              "h-12 w-full rounded-lg border text-sm font-semibold transition-colors",
               selected
-                ? "border-black bg-black text-white"
-                : "border-gray-300 bg-white text-gray-800 hover:bg-gray-50"
+                ? "border-[#1533B6] bg-[#1533B6] text-white"
+                : "border-black bg-white text-black hover:border-[#1533B6] hover:bg-[#1533B6] hover:text-white"
             )}
           >
             {g.name}

--- a/Playproof/src/features/auth/gameSelectPage/components/SignupGameSelectForm.tsx
+++ b/Playproof/src/features/auth/gameSelectPage/components/SignupGameSelectForm.tsx
@@ -1,22 +1,30 @@
 import { Button } from "@/components/ui/Button";
 import { GameSelectGrid } from "@/features/auth/gameSelectPage/components/GameSelectGrid";
-import { useSignupGameSelect } from "@/features/auth/gameSelectPage/hooks/useSignupGameSelect";
+import type { GameOption } from "@/features/auth/gameSelectPage/types";
 
-export function SignupGameSelectForm() {
-  const {
-    games,
-    selectedGame,
-    isPending,
+type SignupGameSelectFormProps = {
+  games: GameOption[];
+  selectedGame: GameOption | null;
+  isPending: boolean;
+  hasAuthCta: boolean;
+  authCtaLabel: string;
+  authCtaClassName: string;
+  onSelectGame: (id: string) => void;
+  onClickManual: () => void;
+  onClickAuth: () => void;
+};
 
-    hasAuthCta,
-    authCtaLabel,
-    authCtaClassName,
-
-    onSelectGame,
-    onClickManual,
-    onClickAuth,
-  } = useSignupGameSelect();
-
+export function SignupGameSelectForm({
+  games,
+  selectedGame,
+  isPending,
+  hasAuthCta,
+  authCtaLabel,
+  authCtaClassName,
+  onSelectGame,
+  onClickManual,
+  onClickAuth,
+}: SignupGameSelectFormProps) {
   return (
     <div className="space-y-5">
       <div className="space-y-2 text-center">
@@ -53,7 +61,7 @@ export function SignupGameSelectForm() {
           {hasAuthCta ? (
             <Button
               type="button"
-              variant="blue"
+              variant="primary"
               fullWidth
               className={`h-10 text-xs ${authCtaClassName}`}
               disabled={isPending}

--- a/Playproof/src/features/auth/gameSelectPage/hooks/useSignupGameSelect.ts
+++ b/Playproof/src/features/auth/gameSelectPage/hooks/useSignupGameSelect.ts
@@ -72,11 +72,11 @@ export function useSignupGameSelect() {
     try {
       // TODO(API 연동): Step2 선택 저장
 
-      navigate("/gameinfo", {
+      navigate("/signup/username", {
         state: {
-          step: 3,
           gameId: selectedGame.id,
           mode: "manual",
+          nextPath: "/gameinfo",
         },
       });
     } finally {

--- a/Playproof/src/features/auth/login/components/LoginForm.tsx
+++ b/Playproof/src/features/auth/login/components/LoginForm.tsx
@@ -47,6 +47,8 @@ export function LoginForm() {
         <Input
           variant="light"
           inputMode="numeric"
+          pattern="[0-9]*"
+          maxLength={11}
           autoComplete="tel"
           placeholder="전화번호를 입력해주세요."
           value={phoneNumber}

--- a/Playproof/src/features/auth/login/components/LoginForm.tsx
+++ b/Playproof/src/features/auth/login/components/LoginForm.tsx
@@ -117,7 +117,7 @@ export function LoginForm() {
       {/* 시작하기 */}
       <Button
         type="submit"
-        variant="blue"
+        variant="primary"
         fullWidth
         disabled={!isFilled || isPending}
         className="h-11"

--- a/Playproof/src/features/auth/login/hooks/useLoginForm.ts
+++ b/Playproof/src/features/auth/login/hooks/useLoginForm.ts
@@ -155,7 +155,7 @@ export function useLoginForm() {
   const onToggleShowPw = () => setShowPw((p) => !p);
 
   const onClickKakao = () => alert("카카오 로그인은 준비중입니다. (추후 API 연동 예정)");
-  const onClickFindPassword = () => alert("비밀번호 찾기는 준비중입니다.");
+  const onClickFindPassword = () => navigate("/find-password");
 
   return {
     phoneNumber,

--- a/Playproof/src/features/auth/pages/FindPasswordPageView.tsx
+++ b/Playproof/src/features/auth/pages/FindPasswordPageView.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+import { AppLayout } from "@/components/layout/AppLayout";
+import { PhoneStep } from "../find-password/components/PhoneStep";
+import { VerificationStep } from "../find-password/components/VerificationStep";
+import { NewPasswordStep } from "../find-password/components/NewPasswordStep";
+import { CompleteStep } from "../find-password/components/CompleteStep";
+
+type Step = "PHONE" | "VERIFY" | "NEW_PW" | "COMPLETE";
+
+export const FindPasswordPageView = () => {
+  const [step, setStep] = useState<Step>("PHONE");
+  const [userData, setUserData] = useState({ phone: "", name: "" });
+
+  const handlePhoneNext = (data: { name: string; phone: string }) => {
+    setUserData(data);
+    setStep("VERIFY");
+  };
+
+  return (
+    <AppLayout>
+      <main className="mx-auto w-full max-w-[1280px] px-8 pb-24 pt-24">
+        <div className="flex justify-center">
+          <div className="w-full max-w-[343px]">
+            {step === "PHONE" && <PhoneStep onNext={handlePhoneNext} />}
+            {step === "VERIFY" && (
+              <VerificationStep 
+                phone={userData.phone} 
+                onNext={() => setStep("NEW_PW")} 
+              />
+            )}
+            {step === "NEW_PW" && <NewPasswordStep onNext={() => setStep("COMPLETE")} />}
+            {step === "COMPLETE" && <CompleteStep />}
+          </div>
+        </div>
+      </main>
+    </AppLayout>
+  );
+};

--- a/Playproof/src/features/auth/pages/LandingPageView.tsx
+++ b/Playproof/src/features/auth/pages/LandingPageView.tsx
@@ -2,10 +2,11 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/Button";
 import { OnboardingPlaceholder } from "@/components/ui/OnboardingPlaceholder";
 import { OnboardingIndicator } from "@/components/ui/OnboardingIndicator";
+import { AppLayout } from "@/components/layout/AppLayout";
 
 export const LandingPageView = () => {
   return (
-    <div className="min-h-screen bg-white text-black">
+    <AppLayout>
       <main className="mx-auto flex min-h-screen max-w-[1280px] flex-col items-center justify-center px-6">
         <div className="w-full max-w-[1232px]">
           <div className="relative">
@@ -18,12 +19,15 @@ export const LandingPageView = () => {
 
         <div className="mt-16 flex w-full flex-col items-center justify-center">
           <Link to="/signup" className="w-full max-w-[604px]">
-            <Button variant="primary" fullWidth>
+            <Button
+              variant="primary"
+              className="flex h-12 w-[604px] max-w-full items-center justify-center gap-2 rounded-lg px-4 py-2"
+            >
               시작하기
             </Button>
           </Link>
         </div>
       </main>
-    </div>
+    </AppLayout>
   );
 };

--- a/Playproof/src/features/auth/pages/LoginPageView.tsx
+++ b/Playproof/src/features/auth/pages/LoginPageView.tsx
@@ -1,14 +1,15 @@
 import { LoginForm } from "@/features/auth/login/components";
+import { AppLayout } from "@/components/layout/AppLayout";
 
 export const LoginPageView = () => {
   return (
-    <div className="min-h-screen bg-white text-black">
+    <AppLayout>
       <main className="mx-auto flex min-h-screen max-w-[980px] flex-col items-center justify-center px-6">
         <div className="w-full max-w-[360px]">
           <h1 className="mb-10 text-center text-2xl font-bold">로그인</h1>
           <LoginForm />
         </div>
       </main>
-    </div>
+    </AppLayout>
   );
 };

--- a/Playproof/src/features/auth/pages/SignupGameInfoPageView.tsx
+++ b/Playproof/src/features/auth/pages/SignupGameInfoPageView.tsx
@@ -1,15 +1,16 @@
 import { StepDots } from "@/components/auth/StepDots";
 import { SignupGameInfoForm } from "@/features/auth/gameInfoPage/components";
+import { AppLayout } from "@/components/layout/AppLayout";
 
 export const SignupGameInfoPageView = () => {
   return (
-    <div className="min-h-screen bg-white text-black">
+    <AppLayout>
       <main className="mx-auto flex min-h-screen max-w-[980px] flex-col items-center px-6 pt-16">
         <div className="w-full max-w-[680px]">
           <StepDots step={3} />
           <SignupGameInfoForm />
         </div>
       </main>
-    </div>
+    </AppLayout>
   );
 };

--- a/Playproof/src/features/auth/pages/SignupGameSelectPageView.tsx
+++ b/Playproof/src/features/auth/pages/SignupGameSelectPageView.tsx
@@ -1,15 +1,53 @@
-import { SignupGameSelectForm } from "@/features/auth/gameSelectPage/components";
+import React from "react";
+import { AppLayout } from "@/components/layout/AppLayout";
 import { StepDots } from "@/components/auth/StepDots";
+import { SignupGameSelectForm } from "@/features/auth/gameSelectPage/components/SignupGameSelectForm";
+import { useSignupGameSelect } from "@/features/auth/gameSelectPage/hooks/useSignupGameSelect";
 
 export const SignupGameSelectPageView = () => {
+  const {
+    games,
+    selectedGame,
+    isPending,
+    hasAuthCta,
+    authCtaLabel,
+    authCtaClassName,
+    onSelectGame,
+    onClickManual,
+    onClickAuth,
+  } = useSignupGameSelect();
+
   return (
-    <div className="min-h-screen bg-white text-black">
-      <main className="mx-auto flex min-h-screen max-w-[980px] flex-col items-center px-6 pt-16">
-        <div className="w-full max-w-[680px] pt-4">
+    <AppLayout>
+      <div className="flex h-full flex-col">
+        <div className="mb-8 px-6 pt-8">
+          {/* [수정] currentStep={3} -> step={3} */}
           <StepDots step={2} />
-          <SignupGameSelectForm />
+          <div className="mt-6">
+            <h1 className="text-2xl font-bold text-zinc-900">
+              플레이하는 게임을<br />
+              선택해주세요
+            </h1>
+            <p className="mt-2 text-sm text-zinc-500">
+              선택한 게임을 기반으로 팀원을 추천해드려요.
+            </p>
+          </div>
         </div>
-      </main>
-    </div>
+
+        <div className="flex-1 overflow-y-auto px-6 pb-24 custom-scrollbar">
+          <SignupGameSelectForm
+            games={games}
+            selectedGame={selectedGame}
+            isPending={isPending}
+            hasAuthCta={hasAuthCta}
+            authCtaLabel={authCtaLabel}
+            authCtaClassName={authCtaClassName}
+            onSelectGame={onSelectGame}
+            onClickManual={onClickManual}
+            onClickAuth={onClickAuth}
+          />
+        </div>
+      </div>
+    </AppLayout>
   );
 };

--- a/Playproof/src/features/auth/pages/SignupPageView.tsx
+++ b/Playproof/src/features/auth/pages/SignupPageView.tsx
@@ -1,9 +1,10 @@
 import SignupForm from "@/features/auth/signup/components/SignupForm";
 import { StepDots } from "@/components/auth/StepDots";
+import { AppLayout } from "@/components/layout/AppLayout";
 
 export const SignupPageView = () => {
   return (
-    <div className="min-h-screen bg-white">
+    <AppLayout>
       <div className="pt-20">
         <StepDots step={1} />
       </div>
@@ -17,6 +18,6 @@ export const SignupPageView = () => {
           </div>
         </div>
       </main>
-    </div>
+    </AppLayout>
   );
 };

--- a/Playproof/src/features/auth/pages/SignupUsernamePageView.tsx
+++ b/Playproof/src/features/auth/pages/SignupUsernamePageView.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { AppLayout } from "@/components/layout/AppLayout";
+import { StepDots } from "@/components/auth/StepDots";
+import { Button } from "@/components/ui/Button";
+
+type LocationState = {
+  nextPath?: string;
+  gameId?: string;
+  mode?: "manual" | "auth";
+};
+
+export const SignupUsernamePageView = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state || {}) as LocationState;
+  const [username, setUsername] = useState("");
+
+  const nextPath = useMemo(() => state.nextPath ?? "/gameinfo", [state.nextPath]);
+  const canSubmit = username.trim().length > 0;
+
+  const onSubmit = () => {
+    if (!canSubmit) return;
+    navigate(nextPath, {
+      state: {
+        step: 3,
+        gameId: state.gameId,
+        mode: state.mode ?? "manual",
+        accountName: username.trim(),
+      },
+    });
+  };
+
+  return (
+    <AppLayout>
+      <div className="flex h-full flex-col">
+        <div className="mb-8 px-6 pt-8">
+          <StepDots step={2} />
+          <div className="mt-6">
+            <h1 className="text-2xl font-bold text-zinc-900">
+              계정 이름을 입력해주세요
+            </h1>
+            <p className="mt-2 text-sm text-zinc-500">
+              이후 단계에서 사용할 계정 이름입니다.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex-1 px-6">
+          <label className="block text-sm font-semibold text-zinc-800">
+            계정 이름
+          </label>
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="계정 이름을 입력해주세요."
+            className="mt-2 h-12 w-full rounded-lg border border-zinc-200 px-4 text-sm outline-none focus:border-[#1533B6]"
+          />
+        </div>
+
+        <div className="px-6 pb-10">
+          <Button
+            type="button"
+            variant={canSubmit ? "primary" : "secondary"}
+            disabled={!canSubmit}
+            fullWidth
+            className="h-12"
+            onClick={onSubmit}
+          >
+            다음
+          </Button>
+        </div>
+      </div>
+    </AppLayout>
+  );
+};

--- a/Playproof/src/features/auth/signup/components/PhoneVerificationSection.tsx
+++ b/Playproof/src/features/auth/signup/components/PhoneVerificationSection.tsx
@@ -1,140 +1,158 @@
-//src/features/auth/signup/components/PhoneVerificationSection.tsx
+// src/features/auth/signup/components/PhoneVerificationSection.tsx
 import { Button } from "@/components/ui/Button";
+import { cn } from "@/utils/cn"; // cn 유틸리티 사용
 
 type Props = {
-    // Phone
-    phone: string;
-    phoneLocked: boolean;
-    phoneError: boolean;
-    onPhoneBlur: () => void;
-    onPhoneChange: (next: string) => void;
+  // Phone
+  phone: string;
+  phoneLocked: boolean;
+  phoneError: boolean;
+  onPhoneBlur: () => void;
+  onPhoneChange: (next: string) => void;
 
-    // SMS request
-    canRequestSms: boolean;
-    smsCooldown: number;
-    onRequestSms: () => void;
+  // SMS request
+  canRequestSms: boolean;
+  smsCooldown: number;
+  onRequestSms: () => void;
 
-    // Code
-    code: string;
-    canTypeCode: boolean;
-    codeTouched: boolean;
-    verifyState: "idle" | "success" | "fail";
-    codeTimeLabel: string; // ex) 4:59
-    onCodeBlur: () => void;
-    onCodeChange: (next: string) => void;
+  // Code
+  code: string;
+  canTypeCode: boolean;
+  codeTouched: boolean;
+  verifyState: "idle" | "success" | "fail";
+  codeTimeLabel: string;
+  onCodeBlur: () => void;
+  onCodeChange: (next: string) => void;
 
-    // Verify
-    canVerify: boolean;
-    onVerifyCode: () => void;
+  // Verify
+  canVerify: boolean;
+  onVerifyCode: () => void;
 };
 
 export const PhoneVerificationSection = ({
-	phone,
-	phoneLocked,
-	phoneError,
-	onPhoneBlur,
-	onPhoneChange,
+  phone,
+  phoneLocked,
+  phoneError,
+  onPhoneBlur,
+  onPhoneChange,
 
-	canRequestSms,
-	onRequestSms,
+  canRequestSms,
+  smsCooldown,
+  onRequestSms,
 
-	code,
-	canTypeCode,
-	codeTouched,
-	verifyState,
-	codeTimeLabel,
-	onCodeBlur,
-	onCodeChange,
+  code,
+  canTypeCode,
+  codeTouched,
+  verifyState,
+  codeTimeLabel,
+  onCodeBlur,
+  onCodeChange,
 
-	canVerify,
-	onVerifyCode,
+  canVerify,
+  onVerifyCode,
 }: Props) => {
-	const showOutline = canRequestSms;
-	const showVerifyOutline = canVerify;
-	
-	return (
-		<section>
-			<div className="mb-3 ml-2 text-lg font-semibold">전화번호*</div>
+  const isVerified = verifyState === "success";
+  const isFail = verifyState === "fail";
 
-			{/* 전화번호 + 인증번호 입력 버튼 */}
-			<div className="mt-6 grid grid-cols-[1fr_100px] gap-1.5">
-				<div className="relative">
-					<input
-						value={phone}
-						disabled={phoneLocked}
-						onBlur={onPhoneBlur}
-						onChange={(e) => onPhoneChange(e.target.value)}
-						placeholder="-없이 전화번호를 입력해주세요."
-						className={[
-						"w-full h-[48px] rounded-lg border px-4 text-xs outline-none",
-						phoneError ? "border-red-500" : "border-[#E5E5E5]",
-						phoneLocked ? "bg-[#F2F2F2] text-[#777]" : "bg-white",
-						].join(" ")}
-					/>
-					{phoneError && (
-						<div className="mt-1 text-xs text-red-500">
-							올바르지 않은 전화번호 형식입니다.
-						</div>
-					)}
-				</div>
+  return (
+    <section>
+      <div className="mb-3 ml-2 text-lg font-semibold text-zinc-900">
+        전화번호<span className="text-red-500">*</span>
+      </div>
 
-				<Button
-					type="button"
-					variant={showOutline ? "outline" : "secondary"}
-					disabled={!canRequestSms}
-					onClick={onRequestSms}
-					className="h-[48px] rounded-lg text-xs whitespace-nowrap"
-				>
-				인증번호 전송
-				</Button>
-			</div>
+      {/* 1. 전화번호 입력 + 전송 버튼 */}
+      <div className="mt-6 grid grid-cols-[1fr_100px] gap-2">
+        <div className="relative">
+          <input
+            value={phone}
+            disabled={phoneLocked}
+            onBlur={onPhoneBlur}
+            onChange={(e) => onPhoneChange(e.target.value)}
+            placeholder="-없이 전화번호를 입력해주세요."
+            className={cn(
+              "h-[48px] w-full rounded-lg border px-4 text-sm outline-none transition-colors",
+              phoneError ? "border-red-500 bg-white" : "border-zinc-200",
+              // [디자인] 인증 완료 시 초록색 스타일
+              isVerified && "border-green-500 bg-green-50 text-green-700 font-medium",
+              // [디자인] 잠금 상태(성공)일 때 스타일
+              phoneLocked && !isVerified && "bg-zinc-100 text-zinc-500"
+            )}
+          />
+          {phoneError && (
+            <div className="mt-1.5 ml-1 text-xs text-red-500 animate-in fade-in">
+              올바르지 않은 전화번호 형식입니다.
+            </div>
+          )}
+        </div>
 
-			{/* 인증번호 입력 + 인증하기 */}
-				<div className="mt-3 grid grid-cols-[1fr_100px] gap-1.5">
-					<div>
-						<input
-							value={code}
-							disabled={!canTypeCode}
-							onBlur={onCodeBlur}
-							onChange={(e) => onCodeChange(e.target.value)}
-							placeholder="인증번호를 입력해주세요."
-							className={[
-							"w-full h-[48px] rounded-lg border px-4 text-xs outline-none",
-							verifyState === "fail" ? "border-red-500" : "border-[#E5E5E5]",
-							!canTypeCode ? "bg-[#F2F2F2] text-[#777]" : "bg-white",
-							].join(" ")}
-						/>
+        <Button
+          type="button"
+          // [디자인] 인증 완료 시 Outline 스타일 + 초록색 텍스트
+          variant={isVerified ? "outline" : canRequestSms ? "primary" : "secondary"}
+          disabled={!canRequestSms && !isVerified}
+          onClick={onRequestSms}
+          className={cn(
+            "h-[48px] rounded-lg text-xs font-medium whitespace-nowrap transition-all",
+            isVerified && "border-green-500 text-green-600 bg-white opacity-100 hover:bg-white cursor-default"
+          )}
+        >
+          {isVerified ? "인증완료" : smsCooldown > 0 ? `${smsCooldown}초` : "인증번호 전송"}
+        </Button>
+      </div>
 
-						{/* 타이머/상태 메시지 */}
-						<div className="flex mt-2 ml-3 text-xs">
-							{canTypeCode && verifyState !== "success" && (
-							<div className="text-[#3B59FF] mr-2">{codeTimeLabel}</div>
-							)}
+      {/* 2. 인증번호 입력 + 확인 버튼 (인증 전송 후 노출) */}
+      {(canTypeCode || isVerified || isFail) && (
+        <div className="mt-2 grid grid-cols-[1fr_100px] gap-2 animate-in fade-in slide-in-from-top-2">
+          <div>
+            <input
+              value={code}
+              disabled={!canTypeCode}
+              onBlur={onCodeBlur}
+              onChange={(e) => onCodeChange(e.target.value)}
+              placeholder="인증번호 6자리"
+              maxLength={6}
+              className={cn(
+                "h-[48px] w-full rounded-lg border px-4 text-sm outline-none transition-colors",
+                isFail ? "border-red-500" : "border-zinc-200",
+                !canTypeCode && !isVerified && "bg-zinc-100 text-zinc-400",
+                // [디자인] 성공 시 초록색 테두리
+                isVerified && "border-green-500 bg-white text-green-700"
+              )}
+            />
 
-							{verifyState === "success" && (
-							<div className="text-[#3B59FF]">
-								인증이 완료되었습니다.
-							</div>
-							)}
+            {/* 상태 메시지 및 타이머 */}
+            <div className="mt-2 ml-1 flex items-center text-xs font-medium min-h-[1.25rem]">
+              {!isVerified && canTypeCode && (
+                <span className="text-blue-600 mr-2">{codeTimeLabel}</span>
+              )}
 
-							{verifyState === "fail" && codeTouched && (
-							<div className="text-red-500">
-								인증번호가 일치하지 않습니다.
-							</div>
-							)}
-						</div>
-					</div>
+              {isVerified && (
+                <span className="text-green-600 flex items-center gap-1">
+                  🎉 인증이 완료되었습니다.
+                </span>
+              )}
 
-					<Button
-						type="button"
-						variant={showVerifyOutline ? "outline" : "secondary"}
-						disabled={!canVerify}
-						onClick={onVerifyCode}
-						className="h-[48px] rounded-lg font-semibold text-xs"
-					>
-					인증하기
-					</Button>
-			</div>
-		</section>
-	);
+              {isFail && codeTouched && (
+                <span className="text-red-500">
+                  인증번호가 일치하지 않습니다.
+                </span>
+              )}
+            </div>
+          </div>
+
+          {!isVerified && (
+            <Button
+              type="button"
+              variant={canVerify ? "primary" : "secondary"}
+              disabled={!canVerify}
+              onClick={onVerifyCode}
+              className="h-[48px] rounded-lg text-xs font-semibold"
+            >
+              인증하기
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
+  );
 };

--- a/Playproof/src/features/auth/signup/components/ProfileSection.tsx
+++ b/Playproof/src/features/auth/signup/components/ProfileSection.tsx
@@ -29,10 +29,6 @@ export const ProfileSection = ({ nicknameProps, avatarIdx, onSelectAvatar }: Pro
     } = nicknameProps;
 
     const canCheck = nickname.length > 0 && nickOk && nickCheckState !== "checking";
-    const showNicknameOutline =
-        nickname.length > 0 &&
-        nickOk &&
-        nickCheckState !== "checking";
 
     return (
         <section>
@@ -62,13 +58,13 @@ export const ProfileSection = ({ nicknameProps, avatarIdx, onSelectAvatar }: Pro
                             <div className="mt-1 text-xs text-red-500">중복된 이름입니다.</div>
                         )}
                         {nickname.length > 0 && nickCheckState === "ok" && (
-                            <div className="mt-1 text-xs text-[#3B59FF]">사용 가능한 이름입니다.</div>
+                            <div className="mt-1 text-xs text-[#1533B6]">사용 가능한 이름입니다.</div>
                         )}
                     </div>
 
                     <Button
                         type="button"
-                        variant={showNicknameOutline ? "outline" : "secondary"}
+                        variant={canCheck ? "primary" : "secondary"}
                         disabled={!canCheck}
                         onClick={onCheckNickname}
                         className="h-[48px] rounded-lg font-semibold text-xs whitespace-nowrap"
@@ -93,8 +89,8 @@ export const ProfileSection = ({ nicknameProps, avatarIdx, onSelectAvatar }: Pro
                                 aria-pressed={selected}
                                 className={[
                                     "aspect-square w-full rounded-lg bg-[#F3F3F3]",
-                                    selected ? "ring-2 ring-black" : "ring-1 ring-transparent",
-                                    "transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-black",
+                                    selected ? "ring-2 ring-[#1533B6]" : "ring-1 ring-transparent",
+                                    "transition hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#1533B6]",
                                 ].join(" ")}
                             />
                         );

--- a/Playproof/src/features/auth/signup/components/SignupCompleteModal.tsx
+++ b/Playproof/src/features/auth/signup/components/SignupCompleteModal.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface SignupCompleteModalProps {
+  isOpen: boolean;
+  nickname?: string;
+}
+
+export const SignupCompleteModal = ({ isOpen, nickname }: SignupCompleteModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-in fade-in duration-300">
+      <div className="w-full max-w-sm mx-6 transform overflow-hidden rounded-2xl bg-white p-8 text-center shadow-xl transition-all animate-in zoom-in-95 duration-300">
+        
+        {/* 아이콘 영역 */}
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-blue-50">
+          <span className="text-3xl" role="img" aria-label="celebration">🎉</span>
+        </div>
+
+        <h2 className="mb-2 text-2xl font-bold text-zinc-900">
+          환영합니다{nickname ? `, ${nickname}님!` : "!"}
+        </h2>
+        
+        <p className="mb-6 text-zinc-600 leading-relaxed">
+          PlayProof의 멤버가 되신 것을 축하드려요.<br />
+          이제 팀원들을 만나러 가볼까요?
+        </p>
+
+        {/* 하단 안내 문구 */}
+        <div className="rounded-xl bg-zinc-50 py-3 px-4">
+          <p className="text-sm text-zinc-500">
+            <span className="font-bold text-blue-600">5초 뒤</span> 자동으로 닫힙니다...
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/Playproof/src/features/auth/signup/hooks/usePhoneVerification.ts
+++ b/Playproof/src/features/auth/signup/hooks/usePhoneVerification.ts
@@ -1,4 +1,4 @@
-//src/features/auth/signup/hooks/usePhoneVerification.ts
+// src/features/auth/signup/hooks/usePhoneVerification.ts
 import { useEffect, useMemo, useState } from "react";
 
 const phoneValid = (v: string) => /^010\d{8}$/.test(v);
@@ -8,144 +8,144 @@ const pad2 = (n: number) => String(n).padStart(2, "0");
 export type VerifyState = "idle" | "success" | "fail";
 
 export const usePhoneVerification = () => {
-    const [phone, setPhone] = useState("");
-    const [phoneTouched, setPhoneTouched] = useState(false);
-    const [phoneLocked, setPhoneLocked] = useState(false);
+  const [phone, setPhone] = useState("");
+  const [phoneTouched, setPhoneTouched] = useState(false);
+  
+  // [수정] phoneLocked 상태 변수 제거 (불필요한 잠금 방지)
 
-    // [수정] _smsSent 상태 제거 (set만 있고 사용되지 않음)
-    const [smsCooldown, setSmsCooldown] = useState(0); 
-    const [code, setCode] = useState("");
-    const [codeTouched, setCodeTouched] = useState(false);
+  const [smsCooldown, setSmsCooldown] = useState(0);
+  const [code, setCode] = useState("");
+  const [codeTouched, setCodeTouched] = useState(false);
 
-    const [codeTimer, setCodeTimer] = useState(0); 
-    const [verifyState, setVerifyState] = useState<VerifyState>("idle");
+  const [codeTimer, setCodeTimer] = useState(0);
+  const [verifyState, setVerifyState] = useState<VerifyState>("idle");
 
-    const [isVerifying, setIsVerifying] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
 
-    const locked = verifyState === "success";
+  // 최종 인증 성공 시에만 잠금
+  const locked = verifyState === "success";
 
-    useEffect(() => {
-        if (smsCooldown <= 0) return;
-        const t = setInterval(() => setSmsCooldown((s) => Math.max(0, s - 1)), 1000);
-        return () => clearInterval(t);
-    }, [smsCooldown]);
+  useEffect(() => {
+    if (smsCooldown <= 0) return;
+    const t = setInterval(() => setSmsCooldown((s) => Math.max(0, s - 1)), 1000);
+    return () => clearInterval(t);
+  }, [smsCooldown]);
 
-    useEffect(() => {
-        if (codeTimer <= 0) return;
-        const t = setInterval(() => setCodeTimer((s) => Math.max(0, s - 1)), 1000);
-        return () => clearInterval(t);
-    }, [codeTimer]);
+  useEffect(() => {
+    if (codeTimer <= 0) return;
+    const t = setInterval(() => setCodeTimer((s) => Math.max(0, s - 1)), 1000);
+    return () => clearInterval(t);
+  }, [codeTimer]);
 
-    const phoneOk = useMemo(() => phoneValid(phone), [phone]);
+  const phoneOk = useMemo(() => phoneValid(phone), [phone]);
 
-    const phoneError = useMemo(() => {
-        if (!phoneTouched) return false;
-        if (phone.length === 0) return false;
-        return !phoneValid(phone);
-    }, [phone, phoneTouched]);
+  const phoneError = useMemo(() => {
+    if (!phoneTouched) return false;
+    if (phone.length === 0) return false;
+    return !phoneValid(phone);
+  }, [phone, phoneTouched]);
 
-    const canRequestSms = useMemo(() => {
-        if (locked) return false;
-        if (phoneLocked) return false;
-        if (!phoneOk) return false;
-        if (smsCooldown > 0) return false;
-        return true;
-    }, [locked, phoneLocked, phoneOk, smsCooldown]);
+  const canRequestSms = useMemo(() => {
+    if (locked) return false;
+    if (!phoneOk) return false;
+    if (smsCooldown > 0) return false;
+    return true;
+  }, [locked, phoneOk, smsCooldown]);
 
-    const codeOk = useMemo(() => /^\d{6}$/.test(code), [code]);
+  const codeOk = useMemo(() => /^\d{6}$/.test(code), [code]);
 
-    const canTypeCode = useMemo(() => {
-        if (!phoneLocked) return false;
-        if (locked) return false;
-        if (isVerifying) return false;
-        return true;
-    }, [phoneLocked, locked, isVerifying]);
+  const canTypeCode = useMemo(() => {
+    if (locked) return false;
+    if (isVerifying) return false;
+    // [수정] 타이머가 돌고 있을 때만 입력 가능
+    return codeTimer > 0;
+  }, [locked, isVerifying, codeTimer]);
 
-    const canVerify = useMemo(() => {
-        if (!canTypeCode) return false;
-        if (locked) return false;
-        if (isVerifying) return false;
-        if (codeTimer <= 0) return false;
-        return codeOk;
-    }, [canTypeCode, locked, isVerifying, codeTimer, codeOk]);
+  const canVerify = useMemo(() => {
+    if (!canTypeCode) return false;
+    if (locked) return false;
+    if (isVerifying) return false;
+    return codeOk;
+  }, [canTypeCode, locked, isVerifying, codeOk]);
 
-    const codeTimeLabel = useMemo(() => {
-        const m = Math.floor(codeTimer / 60);
-        const s = codeTimer % 60;
-        return `${m}:${pad2(s)}`;
-    }, [codeTimer]);
+  const codeTimeLabel = useMemo(() => {
+    const m = Math.floor(codeTimer / 60);
+    const s = codeTimer % 60;
+    return `${m}:${pad2(s)}`;
+  }, [codeTimer]);
 
-    const requestSms = async () => {
-        setPhoneTouched(true);
-        if (!phoneOk) return;
+  const requestSms = async () => {
+    setPhoneTouched(true);
+    if (!phoneOk) return;
 
-        setSmsCooldown(30);
-        setPhoneLocked(true);
+    setSmsCooldown(30);
+    // phoneLocked 제거됨
 
-        setCode("");
-        setCodeTouched(false);
-        setVerifyState("idle");
-        setCodeTimer(5 * 60);
-    };
+    setCode("");
+    setCodeTouched(false);
+    setVerifyState("idle");
+    setCodeTimer(3 * 60); // 3분 (180초)
+  };
 
-    const verifyCode = async () => {
-        setCodeTouched(true);
-        if (!canVerify) return;
+  const verifyCode = async () => {
+    setCodeTouched(true);
+    if (!canVerify) return;
 
-        setIsVerifying(true);
-        try {
-        await new Promise((r) => setTimeout(r, 700));
+    setIsVerifying(true);
+    try {
+      await new Promise((r) => setTimeout(r, 700));
 
-        if (code === "123456") setVerifyState("success");
-        else setVerifyState("fail");
-        } finally {
-        setIsVerifying(false);
-        }
-    };
+      if (code === "123456") setVerifyState("success");
+      else setVerifyState("fail");
+    } finally {
+      setIsVerifying(false);
+    }
+  };
 
-    const uiProps = {
-        phone,
-        phoneLocked: phoneLocked || locked,
-        phoneError,
-        onPhoneBlur: () => setPhoneTouched(true),
-        onPhoneChange: (next: string) => {
-        if (locked) return; 
-        const v = digitsOnly(next).slice(0, 11);
-        setPhone(v);
+  const uiProps = {
+    phone,
+    // [수정] 성공했을 때만 잠금 (입력 수정 시 초기화됨)
+    phoneLocked: locked, 
+    phoneError,
+    onPhoneBlur: () => setPhoneTouched(true),
+    onPhoneChange: (next: string) => {
+      if (locked) return; // 이미 성공했으면 수정 불가
+      const v = digitsOnly(next).slice(0, 11);
+      setPhone(v);
 
-        setSmsCooldown(0);
-        setPhoneLocked(false);
-        setCode("");
-        setCodeTouched(false);
-        setVerifyState("idle");
-        setCodeTimer(0);
-        setIsVerifying(false);
-        },
+      // 번호 변경 시 모든 상태 초기화 (재인증 필요)
+      setSmsCooldown(0);
+      setCode("");
+      setCodeTouched(false);
+      setVerifyState("idle");
+      setCodeTimer(0);
+      setIsVerifying(false);
+    },
 
-        canRequestSms,
-        smsCooldown,
-        onRequestSms: requestSms,
+    canRequestSms,
+    smsCooldown,
+    onRequestSms: requestSms,
 
-        code,
-        canTypeCode,
-        codeTouched,
-        verifyState,
-        codeTimeLabel,
-        onCodeBlur: () => setCodeTouched(true),
-        onCodeChange: (next: string) => {
-        setCode(digitsOnly(next).slice(0, 6));
-        if (verifyState === "fail") setVerifyState("idle");
-        },
+    code,
+    canTypeCode,
+    codeTouched,
+    verifyState,
+    codeTimeLabel,
+    onCodeBlur: () => setCodeTouched(true),
+    onCodeChange: (next: string) => {
+      setCode(digitsOnly(next).slice(0, 6));
+      if (verifyState === "fail") setVerifyState("idle");
+    },
 
-        canVerify,
-        isVerifying,
-        onVerifyCode: verifyCode,
-    };
+    canVerify,
+    isVerifying,
+    onVerifyCode: verifyCode,
+  };
 
-    return {
-        phone,
-        locked,
-        verifyState,
-        uiProps,
-    };
+  return {
+    phone,
+    locked,
+    verifyState,
+    uiProps,
+  };
 };

--- a/Playproof/src/features/home/components/MatchingTabs.tsx
+++ b/Playproof/src/features/home/components/MatchingTabs.tsx
@@ -4,9 +4,10 @@ import { GAME_TABS, MATCHING_TAB_LABELS } from "@/features/home/constants/matchi
 type MatchingTabsProps = {
   activeTab: string;
   onTabChange: (tab: string) => void;
+  onMoreClick?: () => void;
 };
 
-export function MatchingTabs({ activeTab, onTabChange }: MatchingTabsProps) {
+export function MatchingTabs({ activeTab, onTabChange, onMoreClick }: MatchingTabsProps) {
   return (
     <section className="space-y-4">
       {/* 타이틀과 전체보기 버튼 등은 필요하면 유지, 여기서는 타이틀만 남김 */}
@@ -33,7 +34,11 @@ export function MatchingTabs({ activeTab, onTabChange }: MatchingTabsProps) {
           </button>
         ))}
         {/* 우측 '매칭 내역' 버튼 등은 필요시 유지 */}
-        <button className="ml-auto text-sm text-zinc-500 hover:text-zinc-900">
+        <button
+          type="button"
+          onClick={onMoreClick}
+          className="ml-auto text-sm text-zinc-500 hover:text-zinc-900"
+        >
           {MATCHING_TAB_LABELS.history}
         </button>
       </div>

--- a/Playproof/src/features/home/components/sections/HighlightCommunitySection.tsx
+++ b/Playproof/src/features/home/components/sections/HighlightCommunitySection.tsx
@@ -1,15 +1,25 @@
 import * as React from "react";
+import { useNavigate } from "react-router-dom";
 import { CommunityPostCard } from "@/features/home/components/CommunityPostCard";
 import { HOME_ACTION_LABELS, HOME_SECTION_LABELS } from "@/features/home/constants/labels";
+import { useAuthStore } from "@/store/authStore";
 
 export function HighlightCommunitySection() {
+  const authNickname = useAuthStore((s) => s.nickname);
+  const displayName = authNickname ?? "레나";
+  const navigate = useNavigate();
+
   return (
     <section>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-bold text-zinc-900">
           {HOME_SECTION_LABELS.highlightCommunityTitle}
         </h2>
-        <button className="text-sm font-medium text-zinc-600 hover:text-zinc-900">
+        <button
+          type="button"
+          onClick={() => navigate("/community")}
+          className="text-sm font-medium text-zinc-600 hover:text-zinc-900"
+        >
           {HOME_ACTION_LABELS.more}
         </button>
       </div>
@@ -18,7 +28,7 @@ export function HighlightCommunitySection() {
         {Array.from({ length: 3 }).map((_, i) => (
           <CommunityPostCard
             key={i}
-            author="레나"
+            author={displayName}
             date="2025.12.16"
             title="보석 실버 3/4"
             content="어제 레포 했는데 웃겨 죽는줄ㅋㅋㅋㅋㅋㅋ"

--- a/Playproof/src/features/home/components/sections/HomeCommunityHighlightSection.tsx
+++ b/Playproof/src/features/home/components/sections/HomeCommunityHighlightSection.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useNavigate } from "react-router-dom";
 import { HighlightFeed } from "@/features/community/components/HighlightFeed";
 import { HOME_ACTION_LABELS, HOME_SECTION_LABELS } from "@/features/home/constants/labels";
 import type { HighlightPost } from "@/features/community/types";
@@ -12,13 +13,18 @@ export function HomeCommunityHighlightSection({
   posts,
   onPostClick,
 }: HomeCommunityHighlightSectionProps) {
+  const navigate = useNavigate();
   return (
     <section>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-bold text-zinc-900">
           {HOME_SECTION_LABELS.highlightCommunityTitle}
         </h2>
-        <button className="text-sm font-medium text-zinc-600 hover:text-zinc-900">
+        <button
+          type="button"
+          onClick={() => navigate("/community")}
+          className="text-sm font-medium text-zinc-600 hover:text-zinc-900"
+        >
           {HOME_ACTION_LABELS.more}
         </button>
       </div>

--- a/Playproof/src/features/home/components/sections/HomeHotTopicSection.tsx
+++ b/Playproof/src/features/home/components/sections/HomeHotTopicSection.tsx
@@ -1,36 +1,55 @@
 import * as React from "react";
+import type { BoardPost } from "@/features/community/types";
 import { HOME_ACTION_LABELS, HOME_SECTION_LABELS } from "@/features/home/constants/labels";
 
-const HOT_TOPICS = [
-  { title: "레전드 리썰 버그 발견했습니다 ㅋㅋ", stats: "🔥 1,232 좋아요 · 💬 45 댓글" },
-  { title: "브론즈 탈출 꿀팁 공유", stats: "🔥 980 좋아요 · 💬 32 댓글" },
-  { title: "오늘 패치 요약 정리", stats: "🔥 842 좋아요 · 💬 18 댓글" },
-  { title: "컨트롤러 세팅 추천", stats: "🔥 621 좋아요 · 💬 9 댓글" },
-] as const;
+type HomeHotTopicSectionProps = {
+  posts: BoardPost[];
+  onMoreClick?: () => void;
+  onPostClick?: (post: BoardPost) => void;
+};
 
-export function HomeHotTopicSection() {
+export function HomeHotTopicSection({
+  posts,
+  onMoreClick,
+  onPostClick,
+}: HomeHotTopicSectionProps) {
   return (
     <section>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-bold text-zinc-900">
           {HOME_SECTION_LABELS.hotTopicTitle}
         </h2>
-        <button className="text-sm font-medium text-zinc-600 hover:text-zinc-900">
+        <button
+          type="button"
+          onClick={onMoreClick}
+          className="text-sm font-medium text-zinc-600 hover:text-zinc-900"
+        >
           {HOME_ACTION_LABELS.more}
         </button>
       </div>
       <div className="grid gap-4">
-        {HOT_TOPICS.map((topic, i) => (
+        {posts.map((post, i) => (
           <div
-            key={i}
+            key={post.id}
             className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-black/5 flex items-center gap-4 cursor-pointer hover:bg-zinc-50 transition-colors"
+            onClick={() => onPostClick?.(post)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onPostClick?.(post);
+              }
+            }}
           >
             <div className="text-2xl font-bold text-zinc-900 w-8 text-center">
               {i + 1}
             </div>
             <div>
-              <div className="font-semibold text-zinc-900">{topic.title}</div>
-              <div className="text-sm text-zinc-500 mt-1">{topic.stats}</div>
+              <div className="font-semibold text-zinc-900">{post.title}</div>
+              <div className="text-sm text-zinc-500 mt-1">
+                🔥 {post.likes} 좋아요 · 💬 {post.comments} 댓글
+              </div>
             </div>
           </div>
         ))}

--- a/Playproof/src/features/home/components/sections/PopularUsersSection.tsx
+++ b/Playproof/src/features/home/components/sections/PopularUsersSection.tsx
@@ -1,8 +1,12 @@
 import * as React from "react";
 import { PopularUserCard } from "@/features/home/components/PopularUserCard";
 import { HOME_ACTION_LABELS, HOME_SECTION_LABELS } from "@/features/home/constants/labels";
+import { useAuthStore } from "@/store/authStore";
 
 export function PopularUsersSection() {
+  const authNickname = useAuthStore((s) => s.nickname);
+  const displayName = authNickname ?? "레나";
+
   return (
     <section>
       <div className="mb-4 flex items-center justify-between">
@@ -18,7 +22,7 @@ export function PopularUsersSection() {
         {Array.from({ length: 3 }).map((_, i) => (
           <PopularUserCard
             key={i}
-            name="레나"
+            name={displayName}
             tier="실버"
             rank="3/4"
             tags={["#실력 중시", "#욕설 X", "#오더 가능"]}

--- a/Playproof/src/features/home/constants/matchingTabs.ts
+++ b/Playproof/src/features/home/constants/matchingTabs.ts
@@ -1,15 +1,10 @@
-export const GAME_TABS = [
-  "리그오브레전드",
-  "발로란트",
-  "오버워치",
-  "메이플 그룹",
-  "Steam",
-  "기타",
-] as const;
+import { GAME_LIST } from "@/features/matching/constants/matchingConfig";
+
+export const GAME_TABS = GAME_LIST;
 
 export const MATCHING_TAB_LABELS = {
   title: "일반 매칭",
-  history: "내역 →",
+  history: "더보기 →",
   placeholder: "챔피언",
   reset: "초기화",
   search: "검색하기",

--- a/Playproof/src/features/home/pages/HomePageView.tsx
+++ b/Playproof/src/features/home/pages/HomePageView.tsx
@@ -15,6 +15,8 @@ import {
 import { PopularMatchList } from '@/features/matching/components/home/PopularMatchList';
 import { HomeCommunityHighlightSection } from "@/features/home/components/sections/HomeCommunityHighlightSection";
 import { HomeHotTopicSection } from "@/features/home/components/sections/HomeHotTopicSection";
+import { SignupCompleteModal } from "@/components/auth/SignupCompleteModal";
+import { useSignupCompleteModal } from "@/features/auth/signup/hooks/useSignupCompleteModal";
 
 /* 매칭 페이지 핵심 기능 */
 import { 
@@ -78,6 +80,7 @@ const MOCK_HIGHLIGHTS = Array.from({ length: 3 }).map((_, i) => ({
 /* --- Main Component --- */
 
 export const HomePageView = () => {
+  const { open: isSignupCompleteOpen, username, close } = useSignupCompleteModal();
   const [user, setUser] = React.useState<UserSummary | null>(null);
   const [loading, setLoading] = React.useState(true);
   
@@ -207,6 +210,12 @@ export const HomePageView = () => {
 
         </div>
       </main>
+
+      <SignupCompleteModal
+        open={isSignupCompleteOpen}
+        username={username}
+        onClose={close}
+      />
     </div>
   );
 };

--- a/Playproof/src/features/home/pages/HomePageView.tsx
+++ b/Playproof/src/features/home/pages/HomePageView.tsx
@@ -1,6 +1,7 @@
 // src/features/home/pages/HomePageView.tsx
 
 import * as React from "react";
+import { useNavigate } from "react-router-dom";
 import { Navbar } from "@/components/common/Navbar";
 
 /* 홈 전용 컴포넌트  */
@@ -17,6 +18,9 @@ import { HomeCommunityHighlightSection } from "@/features/home/components/sectio
 import { HomeHotTopicSection } from "@/features/home/components/sections/HomeHotTopicSection";
 import { SignupCompleteModal } from "@/components/auth/SignupCompleteModal";
 import { useSignupCompleteModal } from "@/features/auth/signup/hooks/useSignupCompleteModal";
+import { useAuthStore } from "@/store/authStore";
+import { useMatchingDetail } from "@/features/matching/context/MatchingDetailContext";
+import { HighlightDetailModal } from "@/features/community/components";
 
 /* 매칭 페이지 핵심 기능 */
 import { 
@@ -26,6 +30,12 @@ import {
 
 /* 데이터 및 상수 */
 import { fetchUserSummaryMock, type UserSummary } from "@/features/home/data/userSummaryMock";
+import { MOCK_MATCHING_DATA } from "@/features/matching/data/mockMatchingData";
+import { MOCK_MY_AZITS, mockSchedules } from "@/features/team/data/mockTeamData";
+import type { MatchingData } from "@/features/matching/types";
+import type { HighlightPost, BoardPost } from "@/features/community/types";
+import { getBestPosts, getHighlights } from "@/features/community/api/communityApi";
+import { MOCK_COMMENTS } from "@/features/community/data/mockCommunityData";
 import type { FilterState } from "@/features/matching/types";
 
 /* --- Mock Data 정의 (타입 에러 방지용) --- */
@@ -36,58 +46,26 @@ const MOCK_REQUESTS = [
   { id: 2, user: { nickname: "고수2", mannerTier: "TS 99" }, message: "캐리해드림" },
 ];
 
-// 인기 매칭 데이터 (MatchingData 타입 호환)
-const MOCK_POPULAR_MATCHES = Array.from({ length: 4 }).map((_, i) => ({
-  id: i,
-  game: "오버워치 2",
-  title: `경쟁 빡겜 구합니다 ${i + 1}`,
-  tier: "Platinum",
-  tags: ["#빡겜", "#마이크필수"],
-  azit: "강남 아지트",
-  position: ["DPS", "SUP"],
-  memo: "즐겁게 게임하실 분 구해요.",
-  currentMembers: 2,
-  maxMembers: 5,
-  time: "방금 전",
-  views: 120,
-  likes: 12,
-  comments: 4,
-  tsScore: 90,
-  mic: true,
-  hostUser: {
-    id: i + 100,
-    nickname: `유저${i}`,
-    email: `user${i}@example.com`,
-    avatarUrl: undefined,
-    mannerTier: "TS 90",
-  },
-  created: new Date().toISOString()
-}));
-
-// 하이라이트 데이터 (HighlightPost 타입 호환)
-const MOCK_HIGHLIGHTS = Array.from({ length: 3 }).map((_, i) => ({
-  id: i,
-  author: "페이커",
-  date: "2025.12.16",
-  title: "레전드 한타 영상 ㅋㅋㅋ",
-  content: "어제 레포 했는데 웃겨 죽는줄ㅋㅋㅋㅋㅋㅋ",
-  likes: 350,
-  views: 1200,
-  comments: 15,
-  images: ["https://via.placeholder.com/300"], // images 배열 필수
-}));
-
 /* --- Main Component --- */
 
 export const HomePageView = () => {
+  const navigate = useNavigate();
   const { open: isSignupCompleteOpen, username, close } = useSignupCompleteModal();
+  const authNickname = useAuthStore((s) => s.nickname);
+  const { openMatchingDetail } = useMatchingDetail();
+  const displayName = authNickname ?? "사용자";
   const [user, setUser] = React.useState<UserSummary | null>(null);
   const [loading, setLoading] = React.useState(true);
+  const [highlights, setHighlights] = React.useState<HighlightPost[]>([]);
+  const [bestPosts, setBestPosts] = React.useState<BoardPost[]>([]);
+  const [selectedHighlight, setSelectedHighlight] = React.useState<HighlightPost | null>(null);
+  const [isHighlightOpen, setIsHighlightOpen] = React.useState(false);
   
   // 상태 관리
   const [activeGameTab, setActiveGameTab] = React.useState("리그오브레전드");
   const [isFilterOpen, setIsFilterOpen] = React.useState(false); 
   const [searchKeyword, setSearchKeyword] = React.useState(""); 
+  const [azitIndex, setAzitIndex] = React.useState(0);
 
   // 핸들러: 검색 제출
   const handleSearchSubmit = (text: string) => {
@@ -102,15 +80,52 @@ export const HomePageView = () => {
     // TODO: 필터링된 데이터 재조회
   };
 
+  const handleHomeMatchClick = (match: MatchingData) => {
+    openMatchingDetail(match);
+  };
+
+  const handleHighlightClick = (post: HighlightPost) => {
+    setSelectedHighlight(post);
+    setIsHighlightOpen(true);
+  };
+
+  const azitSlides = React.useMemo(() => {
+    const schedules = mockSchedules.length > 0 ? mockSchedules : [undefined];
+    return MOCK_MY_AZITS.map((azit, idx) => {
+      const schedule = schedules[idx % schedules.length];
+      const timeLabel = schedule
+        ? schedule.date.toLocaleTimeString("ko-KR", { hour: "numeric", minute: "2-digit" })
+        : "시간 미정";
+      return { azit, schedule, timeLabel };
+    });
+  }, []);
+
+
+  const filteredPopularMatches = React.useMemo(() => {
+    const matchesByGame = MOCK_MATCHING_DATA.filter(
+      (m) => m.game === activeGameTab
+    );
+
+    return [...matchesByGame]
+      .sort((a, b) => b.views + b.likes - (a.views + a.likes))
+      .slice(0, 10);
+  }, [activeGameTab]);
+
   // 데이터 로딩 (User Summary)
   React.useEffect(() => {
     let alive = true;
     (async () => {
       try {
         setLoading(true);
-        const data = await fetchUserSummaryMock();
+        const [data, highlightData, bestData] = await Promise.all([
+          fetchUserSummaryMock(),
+          getHighlights(1),
+          getBestPosts(),
+        ]);
         if (!alive) return;
         setUser(data);
+        setHighlights(highlightData);
+        setBestPosts(bestData);
       } catch (e) {
         console.error("user summary mock error:", e);
       } finally {
@@ -131,27 +146,69 @@ export const HomePageView = () => {
           {loading && <UserSummaryCardSkeleton />}
           {!loading && user && (
             <UserSummaryCard
-              name={user.name}
+              name={displayName}
               avatarUrl={user.avatarUrl}
               chips={user.chips}
               stats={user.stats}
-              onEdit={() => console.log("edit profile")}
+              onEdit={() => navigate("/mypage")}
             />
           )}
 
           {/* 파티 모집 & 친구 목록 (홈 전용 컴포넌트 사용) */}
           <div className="grid gap-6 lg:grid-cols-3">
             {/* 좌측: 게임 일정 (피그마 디자인 적용된 HomePartyCard) */}
-            <div className="relative lg:col-span-2">
-              <HomePartyCard
-                title="데바데 4인큐"
-                time="오늘 오후 5시"
-                location="아지트 이름"
-                currentPlayers={3}
-                maxPlayers={4}
-                memberAvatars={[]} // 실제 멤버 이미지 URL 배열
-                onClick={() => console.log("참여 확정 클릭")}
-              />
+            <div className="relative lg:col-span-2 group">
+              <div className="relative overflow-hidden">
+                <div
+                  className="flex transition-transform duration-300"
+                  style={{ transform: `translateX(-${azitIndex * 100}%)` }}
+                >
+                  {azitSlides.map((slide) => (
+                    <div key={slide.azit.id} className="w-full shrink-0">
+                      <HomePartyCard
+                        title={slide.schedule?.title ?? "일정 없음"}
+                        time={slide.timeLabel}
+                        location={slide.azit?.name ?? "아지트"}
+                        currentPlayers={slide.schedule?.participants.length ?? 0}
+                        maxPlayers={slide.schedule?.maxParticipants ?? 0}
+                        memberAvatars={[]} // 실제 멤버 이미지 URL 배열
+                        onClick={() =>
+                          navigate("/azit", { state: { azitId: slide.azit.id } })
+                        }
+                      />
+                    </div>
+                  ))}
+                </div>
+
+                {azitSlides.length > 1 ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setAzitIndex((prev) =>
+                          prev <= 0 ? azitSlides.length - 1 : prev - 1
+                        )
+                      }
+                      className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 shadow opacity-0 transition-opacity group-hover:opacity-100 hover:bg-white"
+                      aria-label="이전 아지트"
+                    >
+                      ←
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setAzitIndex((prev) =>
+                          prev >= azitSlides.length - 1 ? 0 : prev + 1
+                        )
+                      }
+                      className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 shadow opacity-0 transition-opacity group-hover:opacity-100 hover:bg-white"
+                      aria-label="다음 아지트"
+                    >
+                      →
+                    </button>
+                  </>
+                ) : null}
+              </div>
             </div>
 
             {/* 우측: 친구 목록 (피그마 디자인 적용된 HomeFriendList) */}
@@ -176,7 +233,8 @@ export const HomePageView = () => {
               {/* 탭 (검색바 제거된 버전) */}
               <MatchingTabs 
                 activeTab={activeGameTab} 
-                onTabChange={setActiveGameTab} 
+                onTabChange={setActiveGameTab}
+                onMoreClick={() => navigate("/matching", { state: { activeGame: activeGameTab } })}
               />
               
               {/* 매칭 페이지와 동일한 검색바 (필터 모달 기능 포함) */}
@@ -184,7 +242,11 @@ export const HomePageView = () => {
                   searchText={searchKeyword}
                   onSearchChange={setSearchKeyword}
                   onSearchSubmit={handleSearchSubmit}
-                  onWriteClick={() => console.log("글쓰기 모달 열기")}
+                  onWriteClick={() =>
+                    navigate("/matching", {
+                      state: { openWriteModal: true, activeGame: activeGameTab },
+                    })
+                  }
                   isFilterOpen={isFilterOpen}
                   onFilterToggle={() => setIsFilterOpen(!isFilterOpen)}
                   onFilterClose={() => setIsFilterOpen(false)}
@@ -196,17 +258,23 @@ export const HomePageView = () => {
             
             {/* 매칭 리스트 */}
             {/* @ts-expect-error : Mock 데이터 타입 호환용 */}
-            <PopularMatchList matches={MOCK_POPULAR_MATCHES} />
+            <PopularMatchList matches={filteredPopularMatches} onCardClick={handleHomeMatchClick} />
           </section>
 
           {/* 하이라이트 커뮤니티 */}
           <HomeCommunityHighlightSection
-            posts={MOCK_HIGHLIGHTS}
-            onPostClick={(post) => console.log("Go to post", post.id)}
+            posts={highlights.slice(0, 3)}
+            onPostClick={handleHighlightClick}
           />
 
           {/* 핫토픽 (간단 리스트) */}
-          <HomeHotTopicSection />
+          <HomeHotTopicSection
+            posts={bestPosts}
+            onMoreClick={() =>
+              navigate({ pathname: "/community", search: "?tab=자유게시판" })
+            }
+            onPostClick={(post) => navigate(`/community/${post.id}?from=자유게시판`)}
+          />
 
         </div>
       </main>
@@ -216,6 +284,14 @@ export const HomePageView = () => {
         username={username}
         onClose={close}
       />
+      {selectedHighlight ? (
+        <HighlightDetailModal
+          post={selectedHighlight}
+          comments={MOCK_COMMENTS}
+          isOpen={isHighlightOpen}
+          onClose={() => setIsHighlightOpen(false)}
+        />
+      ) : null}
     </div>
   );
 };

--- a/Playproof/src/features/matching/components/MatchingCard.tsx
+++ b/Playproof/src/features/matching/components/MatchingCard.tsx
@@ -7,13 +7,18 @@ import { User, MessageCircle, Eye, Settings, Mic } from 'lucide-react';
 
 interface MatchingCardProps {
   data: MatchingData;
+  onOpen?: (data: MatchingData) => void;
 }
 
-export const MatchingCard: React.FC<MatchingCardProps> = ({ data }) => {
+export const MatchingCard: React.FC<MatchingCardProps> = ({ data, onOpen }) => {
   const navigate = useNavigate();
   const { openMatchingDetail } = useMatchingDetail();
 
   const handleCardClick = () => {
+    if (onOpen) {
+      onOpen(data);
+      return;
+    }
     openMatchingDetail(data);
   };
 

--- a/Playproof/src/features/matching/components/MatchingWriteModal.tsx
+++ b/Playproof/src/features/matching/components/MatchingWriteModal.tsx
@@ -14,10 +14,11 @@ interface MatchingWriteModalProps {
   onClose: () => void;
   onUpload: (data: MatchingData, action: 'new' | 'replace' | 'bump') => void;
   existingPosts: MatchingData[];
+  initialGame?: string;
 }
 
 export const MatchingWriteModal: React.FC<MatchingWriteModalProps> = ({ 
-  isOpen, onClose, onUpload, existingPosts 
+  isOpen, onClose, onUpload, existingPosts, initialGame
 }) => {
   const { formState, setters, handlers, isFormValid } = useMatchingWriteForm({ 
     onUpload, onClose, existingPosts 
@@ -27,6 +28,13 @@ export const MatchingWriteModal: React.FC<MatchingWriteModalProps> = ({
     game, title, isProMatch, selectedPositions, tier, azit, 
     memberCount, micStatus, selectedTags, memo, showDuplicateModal 
   } = formState;
+
+  React.useEffect(() => {
+    if (!isOpen || !initialGame) return;
+    if (initialGame !== game) {
+      handlers.handleGameChange(initialGame);
+    }
+  }, [game, handlers, initialGame, isOpen]);
 
   if (!isOpen) return null;
 

--- a/Playproof/src/features/matching/components/PartyRequestBanner.tsx
+++ b/Playproof/src/features/matching/components/PartyRequestBanner.tsx
@@ -72,9 +72,15 @@ export const PartyRequestBanner = () => {
                         <button className="hover:text-black transition-colors"><RefreshCw size={14} /></button>
                     </div>
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div
+                    className="grid grid-flow-col auto-cols-[calc((100%-2*var(--gap))/3)] gap-4 overflow-x-auto pb-2 snap-x snap-mandatory"
+                    style={{ ["--gap" as string]: "16px" }}
+                >
                     {sortedApplicants.map((applicant) => (
-                        <div key={applicant.id} className="bg-white p-5 rounded-xl border border-gray-200 shadow-sm flex flex-col justify-between min-h-[240px]">
+                        <div
+                            key={applicant.id}
+                            className="snap-start bg-white p-5 rounded-xl border border-gray-200 shadow-sm flex flex-col justify-between min-h-[240px]"
+                        >
                             <div className="font-bold text-sm text-gray-900 mb-4 border-b border-gray-50 pb-2 flex justify-between items-center"><span>{applicant.game}</span></div>
                             <div onClick={(e) => handleProfileClick(e, applicant.user)} className="flex flex-col items-center mb-4 cursor-pointer group">
                                 <div className="w-16 h-16 bg-gray-100 rounded-full mb-3 flex items-center justify-center text-gray-400 group-hover:bg-gray-200 transition-colors"><User size={32} /></div>

--- a/Playproof/src/features/matching/components/home/PopularMatchList.tsx
+++ b/Playproof/src/features/matching/components/home/PopularMatchList.tsx
@@ -6,9 +6,10 @@ import type { MatchingData } from '@/features/matching/types';
 
 interface PopularMatchListProps {
   matches: MatchingData[];
+  onCardClick?: (match: MatchingData) => void;
 }
 
-export const PopularMatchList = ({ matches }: PopularMatchListProps) => {
+export const PopularMatchList = ({ matches, onCardClick }: PopularMatchListProps) => {
   return (
     <section>
       <div className="flex items-center justify-between mb-4">
@@ -23,7 +24,7 @@ export const PopularMatchList = ({ matches }: PopularMatchListProps) => {
         <div className="flex gap-4 overflow-x-auto pb-4 -mx-1 px-1 snap-x no-scrollbar">
           {matches.map((item) => (
             <div key={`pop-${item.id}`} className="min-w-[280px] w-[280px] snap-start">
-              <MatchingCard data={item} />
+              <MatchingCard data={item} onOpen={onCardClick} />
             </div>
           ))}
         </div>

--- a/Playproof/src/features/matching/hooks/useMatchingDetailLogic.ts
+++ b/Playproof/src/features/matching/hooks/useMatchingDetailLogic.ts
@@ -17,8 +17,9 @@ export const useMatchingDetailLogic = () => {
   const [commentText, setCommentText] = useState('');
   const [comments, setComments] = useState(MOCK_COMMENTS);
 
-  // 현재 경로가 /matching이 아니면 모달을 숨김
-  const shouldRender = isOpen && selectedPost && location.pathname === '/matching';
+  // 홈에서도 상세 모달 노출
+  const allowPaths = ['/matching', '/home'];
+  const shouldRender = isOpen && selectedPost && allowPaths.includes(location.pathname);
 
   const handleMoveToProfile = (userId: string | number) => {
     navigate(`/user/${userId}`);

--- a/Playproof/src/features/matching/pages/MatchingPageView.tsx
+++ b/Playproof/src/features/matching/pages/MatchingPageView.tsx
@@ -1,16 +1,21 @@
 // src/features/matching/pages/MatchingPageView.tsx
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Navbar } from '@/components/common/Navbar';
 import { MatchingSearchBar, GameFilter, RecommendedSection, PartyRequestBanner, MatchingWriteModal } from '@/features/matching/components';
 import { PopularMatchList } from '@/features/matching/components/home/PopularMatchList';
 import { FilteredMatchList } from '@/features/matching/components/home/FilteredMatchList';
 import { useMatchingBoard } from '@/features/matching/hooks/useMatchingBoard';
 import { GAME_LIST } from '@/features/matching/constants/matchingConfig';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useMatchingDetail } from '@/features/matching/context/MatchingDetailContext';
 
 const CURRENT_USER_ID = 'user-1';
 
 export const MatchingPageView = () => {
   const { state, setters, actions } = useMatchingBoard();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { openMatchingDetail } = useMatchingDetail();
   const {
     allMatches,
     activeGame,
@@ -27,6 +32,31 @@ export const MatchingPageView = () => {
   const recommendedData = useMemo(() => {
     return matchesByGame.slice(0, 10); 
   }, [matchesByGame]);
+
+  useEffect(() => {
+    const state = location.state as { openMatchId?: number; openWriteModal?: boolean; activeGame?: string } | null;
+    const openMatchId = state?.openMatchId;
+    const openWriteModal = state?.openWriteModal;
+    const activeGameFromHome = state?.activeGame;
+
+    if (activeGameFromHome) {
+      setters.setActiveGame(activeGameFromHome);
+    }
+
+    if (openWriteModal) {
+      actions.openWriteModal();
+      navigate('.', { replace: true, state: null });
+      return;
+    }
+
+    if (!openMatchId) return;
+
+    const target = allMatches.find((m) => m.id === openMatchId);
+    if (target) {
+      openMatchingDetail(target);
+      navigate('.', { replace: true, state: null });
+    }
+  }, [actions, allMatches, location.state, navigate, openMatchingDetail, setters]);
 
   return (
     <div className="min-h-screen bg-white text-gray-800 pb-20 font-sans">
@@ -68,6 +98,7 @@ export const MatchingPageView = () => {
         onClose={actions.closeWriteModal}
         onUpload={actions.handleNewPost}
         existingPosts={allMatches.filter((p) => p.hostUser.id === 'me')}
+        initialGame={activeGame}
       />
     </div>
   );

--- a/Playproof/src/features/mypage/pages/MyPageMainView.tsx
+++ b/Playproof/src/features/mypage/pages/MyPageMainView.tsx
@@ -4,11 +4,14 @@ import { ProfileCard, ProfileHeader, MyPageSidebar, SectionContent } from '@/fea
 import { getMyProfile } from '@/features/mypage/api/mypageApi';
 import type { MyProfileData } from '@/features/mypage/types';
 import { MYPAGE_ACTION_LABELS, MYPAGE_SECTION_IDS, MYPAGE_SECTION_LABELS } from '@/features/mypage/constants/labels';
+import { useAuthStore } from '@/store/authStore';
 
 export const MyPageMainView = () => {
   const [activeSection, setActiveSection] = React.useState(
     MYPAGE_SECTION_IDS.profile
   );
+  const authNickname = useAuthStore((s) => s.nickname);
+  const displayNickname = authNickname ?? '사용자';
   const [profileData, setProfileData] = React.useState<MyProfileData | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -86,6 +89,11 @@ export const MyPageMainView = () => {
     );
   }
 
+  const displayProfileData: MyProfileData = {
+    ...profileData,
+    nickname: displayNickname,
+  };
+
   return (
     <>
       <Navbar />
@@ -94,10 +102,10 @@ export const MyPageMainView = () => {
           {/* 상단: 프로필 카드(좌) + 프로필 헤더(우) */}
           <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
             <div className="lg:col-span-1">
-              <ProfileCard profileData={profileData} />
+              <ProfileCard profileData={displayProfileData} />
             </div>
             <div className="lg:col-span-3">
-              <ProfileHeader profileData={profileData} />
+              <ProfileHeader profileData={displayProfileData} />
             </div>
           </div>
 
@@ -108,7 +116,7 @@ export const MyPageMainView = () => {
             </aside>
 
             <main className="lg:col-span-3">
-              <SectionContent activeSection={activeSection} profileData={profileData} />
+              <SectionContent activeSection={activeSection} profileData={displayProfileData} />
             </main>
           </div>
         </div>

--- a/Playproof/src/features/team/components/azit/LeftPanel.tsx
+++ b/Playproof/src/features/team/components/azit/LeftPanel.tsx
@@ -4,11 +4,22 @@ import { Plus, Volume2, Mic } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import type { User } from '@/types';
 
+import type { Schedule } from '@/types';
+
 interface LeftPanelProps {
   members: User[];
+  schedules?: Schedule[];
 }
 
-export const LeftPanel: React.FC<LeftPanelProps> = ({ members }) => {
+export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [] }) => {
+  const mainSchedule = schedules[0];
+  const secondarySchedule = schedules[1];
+  const tertiarySchedule = schedules[2];
+
+  const formatDate = (d?: Date) =>
+    d ? d.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '';
+  const formatTime = (d?: Date) =>
+    d ? d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }) : '';
   return (
     <aside className="w-[340px] flex flex-col gap-6 pr-2 overflow-y-auto pb-10 shrink-0 custom-scrollbar">
       
@@ -33,20 +44,28 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ members }) => {
             <div className="flex gap-4 mb-4">
                {/* 날짜 배지 */}
                <div className="flex flex-col items-center justify-center bg-gray-50 border border-gray-100 rounded-xl w-[52px] h-[52px] shrink-0">
-                  <span className="text-[11px] text-gray-500 font-medium uppercase leading-none mb-0.5">Mon</span>
-                  <span className="text-xl font-bold text-gray-900 leading-none">22</span>
+                  <span className="text-[11px] text-gray-500 font-medium uppercase leading-none mb-0.5">
+                    {mainSchedule ? mainSchedule.date.toLocaleDateString('en-US', { weekday: 'short' }) : '--'}
+                  </span>
+                  <span className="text-xl font-bold text-gray-900 leading-none">
+                    {mainSchedule ? mainSchedule.date.getDate() : '--'}
+                  </span>
                </div>
                
                {/* 내용 */}
                <div className="flex-1 min-w-0">
                  <div className="flex items-center gap-2 mb-1">
-                   <span className="text-lg font-bold text-gray-900 leading-none">20:00</span>
+                   <span className="text-lg font-bold text-gray-900 leading-none">
+                     {formatTime(mainSchedule?.date) || '--:--'}
+                   </span>
                    <Volume2 className="w-4 h-4 text-gray-400" />
                  </div>
-                 <div className="text-sm text-gray-600 font-medium truncate">데바데 5인큐</div>
+                 <div className="text-sm text-gray-600 font-medium truncate">
+                   {mainSchedule?.title ?? '일정 없음'}
+                 </div>
                  {/* 아바타 */}
                  <div className="flex -space-x-1.5 mt-2">
-                    {[1, 2, 3].map((i) => (
+                    {(mainSchedule?.participants ?? []).slice(0, 3).map((_, i) => (
                       <div key={i} className="w-6 h-6 rounded-full bg-gray-200 border-2 border-white" />
                     ))}
                  </div>
@@ -75,12 +94,20 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ members }) => {
           {/* 하위 일정  */}
           <div className="p-4 border-b border-gray-100 last:border-0">
              <div className="flex items-center gap-2 mb-1">
-                <span className="font-bold text-gray-900 text-base">20:00</span>
-                <span className="text-xs text-gray-500 font-medium">2025.12.8</span>
+                <span className="font-bold text-gray-900 text-base">
+                  {formatTime(secondarySchedule?.date) || '--:--'}
+                </span>
+                <span className="text-xs text-gray-500 font-medium">
+                  {formatDate(secondarySchedule?.date)}
+                </span>
              </div>
-             <div className="text-sm text-gray-700 font-medium mb-2">데바데 5인큐</div>
+             <div className="text-sm text-gray-700 font-medium mb-2">
+               {secondarySchedule?.title ?? '일정 없음'}
+             </div>
              <div className="flex items-center gap-1.5 mb-3">
-                {[1,2,3,4,5].map(i => <div key={i} className="w-6 h-6 rounded-full bg-gray-200" />)}
+                {(secondarySchedule?.participants ?? []).slice(0, 5).map((_, i) => (
+                  <div key={i} className="w-6 h-6 rounded-full bg-gray-200" />
+                ))}
              </div>
              <button className="w-full bg-gray-100 text-gray-400 py-2 rounded-lg text-xs font-bold cursor-not-allowed">
                완료
@@ -90,12 +117,20 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ members }) => {
           {/* 하위 일정 2 */}
           <div className="p-4">
              <div className="flex items-center gap-2 mb-1">
-                <span className="font-bold text-gray-900 text-base">20:00</span>
-                <span className="text-xs text-gray-500 font-medium">2025.12.8</span>
+                <span className="font-bold text-gray-900 text-base">
+                  {formatTime(tertiarySchedule?.date) || '--:--'}
+                </span>
+                <span className="text-xs text-gray-500 font-medium">
+                  {formatDate(tertiarySchedule?.date)}
+                </span>
              </div>
-             <div className="text-sm text-gray-700 font-medium mb-2">데바데 3인큐</div>
+             <div className="text-sm text-gray-700 font-medium mb-2">
+               {tertiarySchedule?.title ?? '일정 없음'}
+             </div>
              <div className="flex items-center gap-1.5 mb-3">
-                {[1,2].map(i => <div key={i} className="w-6 h-6 rounded-full bg-gray-200" />)}
+                {(tertiarySchedule?.participants ?? []).slice(0, 2).map((_, i) => (
+                  <div key={i} className="w-6 h-6 rounded-full bg-gray-200" />
+                ))}
              </div>
              <button className="w-full bg-white border border-gray-200 text-gray-600 py-2 rounded-lg text-xs font-bold hover:bg-gray-50 flex items-center justify-center gap-1">
                <Plus className="w-3 h-3" /> 추가 게이머 찾기

--- a/Playproof/src/features/team/data/mockTeamData.ts
+++ b/Playproof/src/features/team/data/mockTeamData.ts
@@ -32,27 +32,90 @@ export const mockMembers: User[] = [
   { id: 5, nickname: '모모', statusMessage: '데바데 할 사람?', isOnline: true },
 ];
 
+export const mockMembersByAzit: Record<number, User[]> = {
+  1: [
+    { id: 1, nickname: '레나', statusMessage: '즐겜 유저', isOnline: true },
+    { id: 2, nickname: '엘릭', statusMessage: 'FE 개발 중...', isOnline: true },
+    { id: 3, nickname: '카이', statusMessage: '밥 먹으러 감', isOnline: false },
+  ],
+  2: [
+    { id: 6, nickname: '로이', statusMessage: 'LoL 랭크 올림', isOnline: true },
+    { id: 7, nickname: '노아', statusMessage: '정글 연습 중', isOnline: true },
+    { id: 8, nickname: '베카', statusMessage: '서폿 유저', isOnline: false },
+  ],
+  3: [
+    { id: 9, nickname: '수지', statusMessage: '스터디 집중', isOnline: true },
+    { id: 10, nickname: '도윤', statusMessage: 'CS 기록 중', isOnline: false },
+    { id: 11, nickname: '하린', statusMessage: '자료 공유 가능', isOnline: true },
+  ],
+};
+
 // 스케줄 목록
 export const mockSchedules: Schedule[] = [
   {
     id: 1,
-    title: '데바데 5인큐',
+    title: '데바데 4인큐',
     type: 'regular',
     date: new Date(new Date().setHours(20, 0, 0, 0)), 
     participants: [mockMembers[0], mockMembers[1], mockMembers[2]],
-    maxParticipants: 5,
+    maxParticipants: 4,
     isCompleted: false,
   },
   {
     id: 2,
-    title: '발로란트 내전',
+    title: '리그 5인 랭크',
     type: 'instant',
-    date: new Date(new Date().setDate(new Date().getDate() + 1)), // 내일
-    participants: [mockMembers[0], mockMembers[4]],
-    maxParticipants: 10,
+    date: new Date(new Date().setDate(new Date().getDate() + 1)),
+    participants: [mockMembers[1], mockMembers[3]],
+    maxParticipants: 5,
+    isCompleted: false,
+  },
+  {
+    id: 3,
+    title: '발로란트 5인 스크림',
+    type: 'regular',
+    date: new Date(new Date().setDate(new Date().getDate() + 2)),
+    participants: [mockMembers[2], mockMembers[4]],
+    maxParticipants: 5,
     isCompleted: false,
   },
 ];
+
+export const mockSchedulesByAzit: Record<number, Schedule[]> = {
+  1: [
+    {
+      id: 1,
+      title: '데바데 4인큐',
+      type: 'regular',
+      date: new Date(new Date().setHours(20, 0, 0, 0)),
+      participants: [mockMembers[0], mockMembers[1], mockMembers[2]],
+      maxParticipants: 4,
+      isCompleted: false,
+    },
+  ],
+  2: [
+    {
+      id: 2,
+      title: '리그 5인 랭크',
+      type: 'instant',
+      date: new Date(new Date().setDate(new Date().getDate() + 1)),
+      participants: [mockMembers[1], mockMembers[3]],
+      maxParticipants: 5,
+      isCompleted: false,
+    },
+  ],
+  3: [
+    {
+      id: 3,
+      title: '발로란트 5인 스크림',
+      type: 'regular',
+      date: new Date(new Date().setDate(new Date().getDate() + 2)),
+      participants: [mockMembers[2], mockMembers[4]],
+      maxParticipants: 5,
+      isCompleted: false,
+    },
+  ],
+};
 
 // 음성/채팅 채널 목록
 export const mockVoiceChannels: Channel[] = [
@@ -116,3 +179,39 @@ export const mockClips: Clip[] = [
     createdAt: '3일 전',
   },
 ];
+
+export const mockClipsByAzit: Record<number, Clip[]> = {
+  1: [
+    {
+      id: 1,
+      title: '펜타킬 하이라이트',
+      author: '레나',
+      thumbnailUrl: 'https://via.placeholder.com/300x160/000000/FFFFFF?text=PentaKill',
+      views: 120,
+      duration: '0:45',
+      createdAt: '2시간 전',
+    },
+  ],
+  2: [
+    {
+      id: 2,
+      title: '리그 역전 하이라이트',
+      author: '로이',
+      thumbnailUrl: 'https://via.placeholder.com/300x160/2563eb/FFFFFF?text=LoL',
+      views: 210,
+      duration: '1:05',
+      createdAt: '5시간 전',
+    },
+  ],
+  3: [
+    {
+      id: 3,
+      title: '스터디 밈 모음',
+      author: '수지',
+      thumbnailUrl: 'https://via.placeholder.com/300x160/16a34a/FFFFFF?text=Study',
+      views: 45,
+      duration: '0:30',
+      createdAt: '어제',
+    },
+  ],
+};

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -1,5 +1,6 @@
 // src/features/team/pages/AzitPageView.tsx
 import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Settings, Users } from 'lucide-react';
 import { Navbar } from '@/components/common/Navbar';
 
@@ -8,11 +9,21 @@ import { AzitNavigation } from '@/features/team/components/azit/AzitNavigation';
 import { LeftPanel } from '@/features/team/components/azit/LeftPanel';
 import { MainPanel } from '@/features/team/components/azit/MainPanel';
 import { RightPanel } from '@/features/team/components/azit/RightPanel';
-import { MOCK_MY_AZITS, mockMembers, mockClips } from '@/features/team/data/mockTeamData';
+import {
+  MOCK_MY_AZITS,
+  mockClipsByAzit,
+  mockMembersByAzit,
+  mockSchedulesByAzit,
+} from '@/features/team/data/mockTeamData';
 
 export const AzitPageView = () => {
-  const [currentAzitId, setCurrentAzitId] = useState<number>(1);
+  const location = useLocation();
+  const state = location.state as { azitId?: number } | null;
+  const [currentAzitId, setCurrentAzitId] = useState<number>(state?.azitId ?? 1);
   const currentAzit = MOCK_MY_AZITS.find(a => a.id === currentAzitId) || MOCK_MY_AZITS[0];
+  const currentMembers = mockMembersByAzit[currentAzitId] ?? mockMembersByAzit[1];
+  const currentClips = mockClipsByAzit[currentAzitId] ?? mockClipsByAzit[1];
+  const currentSchedules = mockSchedulesByAzit[currentAzitId] ?? mockSchedulesByAzit[1];
 
   return (
     <div className="flex flex-col h-screen bg-white">
@@ -48,7 +59,7 @@ export const AzitPageView = () => {
 
         {/* Content Layout */}
         <div className="flex flex-1 px-6 pb-6 gap-8 overflow-hidden">
-          <LeftPanel members={mockMembers} />
+          <LeftPanel members={currentMembers} schedules={currentSchedules} />
           {/* 아지트 변경 시 채팅 상태 리셋을 위해 key prop 사용 */}
           <MainPanel key={currentAzitId} />
           
@@ -57,7 +68,7 @@ export const AzitPageView = () => {
                <h2 className="text-lg font-bold text-gray-900">하이라이트</h2>
                <button className="text-xs text-gray-500 underline font-medium">전체보기</button>
              </div>
-             <RightPanel clips={mockClips} />
+             <RightPanel clips={currentClips} />
           </div>
         </div>
       </div>

--- a/Playproof/src/pages/auth/FindPasswordPage.tsx
+++ b/Playproof/src/pages/auth/FindPasswordPage.tsx
@@ -1,0 +1,7 @@
+import { FindPasswordPageView } from "@/features/auth/pages/FindPasswordPageView";
+
+const FindPasswordPage = () => {
+  return <FindPasswordPageView />;
+};
+
+export default FindPasswordPage;

--- a/Playproof/src/pages/auth/SignupUsernamePage.tsx
+++ b/Playproof/src/pages/auth/SignupUsernamePage.tsx
@@ -1,0 +1,7 @@
+import { SignupUsernamePageView } from "@/features/auth/pages/SignupUsernamePageView";
+
+const SignupUsernamePage = () => {
+  return <SignupUsernamePageView />;
+};
+
+export default SignupUsernamePage;


### PR DESCRIPTION
# feat: 홈 화면 데이터 도메인 통합 및 네비게이션 로직 고도화

## 개요
- 서비스 전반의 사용자 동선을 최적화하기 위해 각 도메인(홈, 매칭, 커뮤니티, 아지트) 간의 데이터 연동 및 네비게이션 로직을 고도화했습니다.
- 홈 화면을 서비스의 허브로 기능하도록 모든 섹션의 데이터 소스를 통합하고, 인기 매칭 카드 클릭 시 발생하던 프리징 버그를 해결했습니다.
- 사용자 정보 표시를 통일하고, 복잡한 리스트 UI를 캐러셀 방식으로 개선하여 서비스의 전반적인 완성도를 높였습니다.

---

## 주요 변경 사항

### 1. 글로벌 네비게이션 및 사용자 정보 동기화
- **사용자 정보 통일**: 네비바, 홈, 마이페이지 등 서비스 전반에서 로그인 유저의 닉네임을 우선적으로 표시하도록 수정했습니다.
- **프로필 이동**: 홈 상단 프로필 편집 버튼 클릭 시 마이페이지 내 프로필 수정 페이지로 이동하도록 경로를 연동했습니다.
- **스크롤 관리**: 홈에서 다른 페이지로 이동 시 브라우저 스크롤 위치를 항상 최상단으로 고정하는 로직을 적용했습니다.

### 2. 홈-매칭 도메인 간 데이터 연동 및 통합
- **데이터 및 필터 통합**: 
  - 홈 매칭 탭의 게임 목록을 매칭 페이지의 `GAME_LIST`와 동기화했습니다.
  - 홈 인기 매칭 섹션에 매칭 도메인의 데이터 소스를 재사용하고 탭 필터 로직을 적용했습니다.
- **모달 시스템 통합**: 
  - 홈에서 매칭 카드 클릭 시 상세 모달이 즉시 열리도록 구현했습니다.
  - 홈 글쓰기 버튼 클릭 시 매칭 페이지의 작성 모달이 열리며 선택된 게임 상태가 유지되도록 연동했습니다.
- **더보기 로직**: "일반 매칭 더보기" 클릭 시 선택했던 게임 필터가 적용된 상태로 매칭 페이지로 이동합니다.

### 3. 실시간 커뮤니티 데이터 연동 (핫토픽/하이라이트)
- **핫토픽**: `getBestPosts` 데이터를 사용하여 자유게시판 상위 게시글을 홈에 노출하고, 클릭 시 해당 게시물 상세 페이지로 이동하도록 구현했습니다. (더보기 클릭 시 자유게시판 탭 이동)
- **하이라이트**: 최신 상위 3개 게시물만 노출하도록 필터링하고, 카드 클릭 시 상세 모달 오픈 및 더보기 클릭 시 커뮤니티 이동 기능을 연결했습니다.

### 4. 아지트 데이터 동기화 및 UI 고도화
- **아지트 스케줄**: 홈 아지트 일정 카드를 실제 데이터와 연결하고, 클릭 시 선택된 아지트의 ID를 `state`로 전달하여 해당 아지트가 바로 열리도록 구현했습니다.
- **캐러셀 및 UI 개선**: 
  - 아지트 일정 카드에 캐러셀을 적용하고 Hover 시 이동 버튼이 노출되도록 제어 로직을 추가했습니다.
  - 파티 참가 요청 목록을 좌우 스크롤 캐러셀로 변경하고, 정확히 3개가 노출되도록 레이아웃을 최적화했습니다.
- **아지트 네비게이션**: 내부 메뉴(멤버/클립/스케줄) 선택에 따라 해당 데이터가 동적으로 변경되도록 연동했습니다.

---

## 테스트
- [x] 홈 상단 프로필 버튼 클릭 시 마이페이지 내 프로필로 정상 이동 확인.
- [x] 전역 네비바 및 각 페이지에서 사용자 닉네임이 일관되게 표시되는가?
- [x] 홈 매칭/하이라이트 카드 클릭 시 상세 모달이 정상적으로 오픈되는가?
- [x] 아지트 이동 시 선택한 아지트의 데이터가 `state`를 통해 정상 로드되는가?
- [x] 홈 화면 인기 매칭 카드 클릭 시 프리징 현상이 해결되었는가?
- [x] 페이지 이동 후 스크롤이 항상 최상단에 고정되는가?

---

## 관련 이슈
- Closes #29 
- Closes #30 
- Closes #31 
- Closes #32 
- Closes #33

---

## 기타
- 관련 브랜치: fix/home-bug-and-navigation_Elric
- 모든 데이터 연동은 기존의 프로젝트 구조 및 타입 정의를 준수하여 구현되었습니다.