### PR TITLE
feat: 아지트 시스템 전면 개편 및 반응형 UI/UX 고도화

### DIFF
--- a/Playproof/src/components/common/Navbar.tsx
+++ b/Playproof/src/components/common/Navbar.tsx
@@ -1,7 +1,7 @@
 // src/components/common/Navbar.tsx
 import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { Bell, Settings, User, ChevronDown, CreditCard, ShoppingCart, LogOut, FileText, Gamepad2 } from 'lucide-react';
+import { Bell, Settings, User, ChevronDown, CreditCard, ShoppingCart, LogOut, FileText, Gamepad2, Menu, X } from 'lucide-react';
 import { NotificationDropdown } from '@/features/notification/components';
 import { NAV_LINKS } from '@/constants/navigation';
 import { Button } from '@/components/ui/Button';
@@ -20,6 +20,7 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
   
   const [isNotiOpen, setIsNotiOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
   
   // 드롭다운 외부 클릭 감지를 위한 Ref
   const profileRef = useRef<HTMLDivElement>(null);
@@ -117,6 +118,14 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
         
         {/* 1. 로고 및 네비게이션 */}
         <div className="flex items-center gap-8">
+          <button
+            type="button"
+            onClick={() => setIsMobileOpen(true)}
+            className="md:hidden p-2 rounded-full hover:bg-gray-100 text-gray-600"
+            aria-label="메뉴 열기"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
           <div className="flex items-center gap-1 cursor-pointer" onClick={() => navigate('/home')}>
             <h1 className="text-2xl font-black tracking-tighter">PLAYPROOF</h1>
             <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-xs font-medium text-zinc-600">Pro</span>
@@ -221,6 +230,68 @@ export const Navbar: React.FC<NavbarProps> = ({ isProUser = true, onTogglePro })
           )}
         </div>
       </div>
+
+      {/* 모바일 네비게이션 */}
+      {isMobileOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-[120] bg-black/40"
+            onClick={() => setIsMobileOpen(false)}
+          />
+          <aside className="fixed left-0 top-0 z-[121] h-full w-[280px] bg-white shadow-2xl border-r border-gray-200 p-6 flex flex-col">
+            <div className="flex items-center justify-between mb-6">
+              <div className="flex items-center gap-1">
+                <h2 className="text-lg font-black tracking-tighter">PLAYPROOF</h2>
+                <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600">Pro</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsMobileOpen(false)}
+                className="p-2 rounded-full hover:bg-gray-100 text-gray-600"
+                aria-label="메뉴 닫기"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <nav className="flex flex-col gap-2 text-sm font-medium text-gray-700">
+              {NAV_LINKS.map((item) => (
+                <button
+                  key={item.path}
+                  onClick={() => {
+                    navigate(item.path);
+                    setIsMobileOpen(false);
+                  }}
+                  className={`w-full text-left px-3 py-2 rounded-lg transition-colors ${
+                    isActive(item.path) ? "bg-gray-100 text-black" : "hover:bg-gray-50"
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </nav>
+
+            <div className="mt-6 border-t border-gray-200 pt-4">
+              {isAuthPage ? (
+                <Button
+                  variant="primary"
+                  className="w-full h-10 rounded-md text-sm"
+                  onClick={() => {
+                    navigate('/login');
+                    setIsMobileOpen(false);
+                  }}
+                >
+                  로그인
+                </Button>
+              ) : (
+                <div className="rounded-xl border border-gray-200 overflow-hidden">
+                  {renderProfileMenu()}
+                </div>
+              )}
+            </div>
+          </aside>
+        </>
+      )}
     </header>
   );
 };

--- a/Playproof/src/components/ui/ModalShell.tsx
+++ b/Playproof/src/components/ui/ModalShell.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+type ModalShellProps = {
+  open: boolean;
+  onOverlayClick?: () => void;
+  overlayClassName?: string;
+  wrapperClassName?: string;
+  panelClassName?: string;
+  children: React.ReactNode;
+};
+
+export const ModalShell = ({
+  open,
+  onOverlayClick,
+  overlayClassName = "fixed inset-0 z-[120] bg-black/30",
+  wrapperClassName = "fixed inset-0 z-[121] flex items-center justify-center px-6",
+  panelClassName = "w-full max-w-[640px] bg-white rounded-2xl shadow-2xl border border-gray-100",
+  children,
+}: ModalShellProps) => {
+  if (!open) return null;
+
+  return (
+    <>
+      <div className={overlayClassName} onClick={onOverlayClick} />
+      <div className={wrapperClassName}>
+        <div className={panelClassName}>{children}</div>
+      </div>
+    </>
+  );
+};

--- a/Playproof/src/features/community/components/HighlightDetailModal.tsx
+++ b/Playproof/src/features/community/components/HighlightDetailModal.tsx
@@ -52,6 +52,14 @@ function HighlightDetailModalContent({
   const { state, refs, actions } = useHighlightDetailState(post);
   const resolvedProfileUserId = profileUserId ?? "user-1";
 
+  React.useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
   const handleMoveToProfile = (event: React.MouseEvent, userId: string) => {
     event.stopPropagation();
     navigate(`/user/${userId}`);
@@ -97,7 +105,7 @@ function HighlightDetailModalContent({
       onClick={handleBackdropClick}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
     >
-      <div className="relative flex h-[90vh] w-full max-w-6xl overflow-hidden rounded-2xl bg-white shadow-2xl">
+      <div className="relative flex h-[90vh] w-full max-w-6xl flex-col overflow-y-auto md:overflow-hidden rounded-2xl bg-white shadow-2xl md:flex-row">
         <button
           onClick={onClose}
           className="absolute right-4 top-4 z-10 rounded-full bg-white/90 p-2 text-gray-600 hover:bg-white hover:text-gray-900"

--- a/Playproof/src/features/community/components/HighlightWriteModal.tsx
+++ b/Playproof/src/features/community/components/HighlightWriteModal.tsx
@@ -6,21 +6,34 @@ type HighlightWriteModalProps = {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (payload: { title?: string; content: string; images: File[] }) => void;
+  initialImages?: File[];
 };
 
-export function HighlightWriteModal({ isOpen, onClose, onSubmit }: HighlightWriteModalProps) {
+export function HighlightWriteModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  initialImages,
+}: HighlightWriteModalProps) {
   if (!isOpen) return null;
 
-  return <HighlightWriteModalContent onClose={onClose} onSubmit={onSubmit} />;
+  return (
+    <HighlightWriteModalContent
+      onClose={onClose}
+      onSubmit={onSubmit}
+      initialImages={initialImages}
+    />
+  );
 }
 
 function HighlightWriteModalContent({
   onClose,
   onSubmit,
+  initialImages = [],
 }: Omit<HighlightWriteModalProps, "isOpen">) {
   const [title] = useState("");
   const [content, setContent] = useState("");
-  const [images, setImages] = useState<File[]>([]);
+  const [images, setImages] = useState<File[]>(initialImages);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -48,7 +61,7 @@ function HighlightWriteModalContent({
         <form onSubmit={handleSubmit} className="px-6 py-5 max-h-[calc(90vh-96px)] overflow-y-auto">
           <div className="space-y-4">
             <div>
-              <WriteModalUploadBox onFilesChange={setImages} />
+              <WriteModalUploadBox onFilesChange={setImages} initialFiles={initialImages} />
             </div>
 
             <div>

--- a/Playproof/src/features/community/components/WriteModalUploadBox.tsx
+++ b/Playproof/src/features/community/components/WriteModalUploadBox.tsx
@@ -6,6 +6,7 @@ type WriteModalUploadBoxProps = {
   accept?: string;
   multiple?: boolean;
   onFilesChange: (files: File[]) => void;
+  initialFiles?: File[];
 };
 
 export const WriteModalUploadBox = ({
@@ -14,6 +15,7 @@ export const WriteModalUploadBox = ({
   accept = "image/*",
   multiple = true,
   onFilesChange,
+  initialFiles = [],
 }: WriteModalUploadBoxProps) => {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const [previews, setPreviews] = React.useState<string[]>([]);
@@ -64,9 +66,17 @@ export const WriteModalUploadBox = ({
   };
 
   React.useEffect(() => {
-    clearPreviews();
+    if (!initialFiles.length) {
+      clearPreviews();
+      return;
+    }
+    previews.forEach((url) => URL.revokeObjectURL(url));
+    const nextPreviews = initialFiles.map((file) => URL.createObjectURL(file));
+    setSelectedFiles(initialFiles);
+    setPreviews(nextPreviews);
+    onFilesChange(initialFiles);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [initialFiles]);
 
   return (
     <div>

--- a/Playproof/src/features/community/components/highlight-detail/HighlightDetailCommentsPanel.tsx
+++ b/Playproof/src/features/community/components/highlight-detail/HighlightDetailCommentsPanel.tsx
@@ -69,7 +69,7 @@ export function HighlightDetailCommentsPanel({
   profileUserId,
 }: HighlightDetailCommentsPanelProps) {
   return (
-    <div className="flex w-2/5 flex-col">
+    <div className="flex w-full md:w-2/5 flex-col border-t border-gray-200 md:border-t-0 md:border-l min-h-0">
       <div className="flex-1 overflow-y-auto p-4">
         <h3 className="mb-4 text-sm font-semibold text-gray-900">
           {COMMUNITY_SECTION_LABELS.comments} {totalCommentCount}
@@ -112,7 +112,7 @@ export function HighlightDetailCommentsPanel({
           event.preventDefault();
           onCommentSubmit();
         }}
-        className="border-t border-gray-200 p-4"
+        className="border-t border-gray-200 p-4 bg-white md:static md:bg-transparent sticky bottom-0"
       >
         <div className="flex items-center gap-2">
           <input

--- a/Playproof/src/features/community/components/highlight-detail/HighlightDetailMediaPanel.tsx
+++ b/Playproof/src/features/community/components/highlight-detail/HighlightDetailMediaPanel.tsx
@@ -27,7 +27,7 @@ export function HighlightDetailMediaPanel({
   profileUserId,
 }: HighlightDetailMediaPanelProps) {
   return (
-    <div className="relative flex w-3/5 flex-col bg-white">
+    <div className="relative flex w-full md:w-3/5 flex-col bg-white min-h-0">
       <div className="border-b border-gray-200 p-5">
         <div className="flex items-center gap-3">
           <div

--- a/Playproof/src/features/community/pages/CommunityPageView.tsx
+++ b/Playproof/src/features/community/pages/CommunityPageView.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Navbar } from "@/components/common/Navbar";
 import {
   CommunityTabs,
@@ -19,6 +21,34 @@ const COMMUNITY_BOARD_GAMES = ["전체글", ...GAME_LIST];
 
 export const CommunityPageView = () => {
   const { ui, data, modal, user, actions } = useCommunityPageLogic();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [sharedFiles, setSharedFiles] = React.useState<File[]>([]);
+  const shareState = location.state as { shareFiles?: File[] } | null;
+
+  React.useEffect(() => {
+    if (!shareState?.shareFiles || shareState.shareFiles.length === 0) return;
+    if (ui.activeTab !== COMMUNITY_PAGE_LABELS.highlightTab) {
+      actions.tab.change(COMMUNITY_PAGE_LABELS.highlightTab);
+    }
+    setSharedFiles(shareState.shareFiles);
+    actions.modal.setWriteOpen(true);
+    navigate(`${location.pathname}${location.search}`, { replace: true, state: {} });
+  }, [
+    actions.modal,
+    actions.tab,
+    navigate,
+    location.pathname,
+    location.search,
+    shareState,
+    ui.activeTab,
+  ]);
+
+  React.useEffect(() => {
+    if (!modal.isWriteOpen && sharedFiles.length > 0) {
+      setSharedFiles([]);
+    }
+  }, [modal.isWriteOpen, sharedFiles.length]);
 
   return (
     <div className="min-h-screen bg-zinc-50">
@@ -121,6 +151,7 @@ export const CommunityPageView = () => {
           isOpen={modal.isWriteOpen}
           onClose={() => actions.modal.setWriteOpen(false)}
           onSubmit={actions.write.submit}
+          initialImages={sharedFiles}
         />
       )}
     </div>

--- a/Playproof/src/features/home/hooks/useHomePageLogic.ts
+++ b/Playproof/src/features/home/hooks/useHomePageLogic.ts
@@ -77,8 +77,8 @@ export const useHomePageLogic = (): UseHomePageLogicReturn => {
     const schedules = mockSchedules.length > 0 ? mockSchedules : [undefined];
     return MOCK_MY_AZITS.map((azit, idx) => {
       const schedule = schedules[idx % schedules.length];
-      const timeLabel = schedule
-        ? schedule.date.toLocaleTimeString("ko-KR", { hour: "numeric", minute: "2-digit" })
+      const timeLabel = schedule?.fullDate
+        ? schedule.fullDate.toLocaleTimeString("ko-KR", { hour: "numeric", minute: "2-digit" })
         : "시간 미정";
       return { azit, schedule, timeLabel };
     });

--- a/Playproof/src/features/matching/pages/MatchingPageView.tsx
+++ b/Playproof/src/features/matching/pages/MatchingPageView.tsx
@@ -9,6 +9,11 @@ import { GAME_LIST } from '@/features/matching/constants/matchingConfig';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMatchingDetail } from '@/features/matching/context/MatchingDetailContext';
 import { useAuthStore } from '@/store/authStore';
+import { FeedbackModal } from "@/features/team/components/feedback/FeedbackModal";
+import {
+  getPendingFeedbacks,
+  removePendingFeedback,
+} from "@/features/team/utils/pendingFeedback";
 
 const FALLBACK_USER_ID = 'user-1';
 
@@ -30,6 +35,9 @@ export const MatchingPageView = () => {
     popularMatches,
     filteredMatches,
   } = state;
+  const [pendingFeedback, setPendingFeedback] = React.useState(
+    getPendingFeedbacks()[0]
+  );
 
   // 수정됨: 4개 이상일 때 스크롤을 확인하기 위해 3개 제한을 10개로 늘림
   const recommendedData = useMemo(() => {
@@ -107,6 +115,17 @@ export const MatchingPageView = () => {
         onUpload={actions.handleNewPost}
         existingPosts={allMatches.filter((p) => p.hostUser.id === currentUserId)}
         initialGame={activeGame}
+      />
+
+      <FeedbackModal
+        open={Boolean(pendingFeedback)}
+        required
+        targetName={pendingFeedback?.targetName ?? "상대방"}
+        onSubmit={() => {
+    if (!pendingFeedback) return;
+    removePendingFeedback(pendingFeedback.scheduleId, pendingFeedback.azitId);
+    setPendingFeedback(getPendingFeedbacks()[0]);
+  }}
       />
     </div>
   );

--- a/Playproof/src/features/team/components/ClipList.tsx
+++ b/Playproof/src/features/team/components/ClipList.tsx
@@ -6,15 +6,21 @@ import { Card } from '@/components/ui/Card';
 
 interface Props {
   clips: Clip[];
+  onViewAll?: () => void;
+  onSelectClip?: (clip: Clip, index: number) => void;
 }
 
-export const ClipList: React.FC<Props> = ({ clips }) => {
+export const ClipList: React.FC<Props> = ({ clips, onViewAll, onSelectClip }) => {
   return (
     <section className="flex-1">
       {/* 헤더 (박스 바깥) */}
       <div className="flex justify-between items-center mb-2 px-1">
         <h3 className="font-bold text-base text-gray-900">최근 클립</h3>
-        <button className="text-xs text-gray-500 hover:text-gray-900 flex items-center hover:underline">
+        <button
+          type="button"
+          onClick={onViewAll}
+          className="text-xs text-gray-500 hover:text-gray-900 flex items-center hover:underline"
+        >
           전체보기
         </button>
       </div>
@@ -23,8 +29,13 @@ export const ClipList: React.FC<Props> = ({ clips }) => {
       <Card className="p-5">
         {/* 타임라인 줄 (왼쪽 세로선) */}
         <div className="relative border-l-2 border-gray-100 ml-2 space-y-6 pb-2">
-          {clips.map((clip) => (
-            <div key={clip.id} className="pl-5 relative group cursor-pointer">
+          {clips.map((clip, index) => (
+            <button
+              key={clip.id}
+              type="button"
+              onClick={() => onSelectClip?.(clip, index)}
+              className="pl-5 relative group cursor-pointer text-left w-full"
+            >
               
               {/* 타임라인 점 (Dot) */}
               <div className="absolute -left-[5px] top-1 w-2.5 h-2.5 bg-gray-300 rounded-full border-2 border-white group-hover:bg-indigo-500 transition-colors"></div>
@@ -36,22 +47,41 @@ export const ClipList: React.FC<Props> = ({ clips }) => {
 
               {/* 썸네일 박스 */}
               <div className="w-full aspect-video bg-gray-100 rounded-lg border border-gray-200 overflow-hidden relative">
-                {clip.thumbnailUrl ? (
-                  <img src={clip.thumbnailUrl} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" alt="클립 썸네일"/>
+                {clip.mediaType === "video" && clip.mediaUrl ? (
+                  <video
+                    src={clip.mediaUrl}
+                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                    muted
+                    playsInline
+                  />
+                ) : clip.thumbnailUrl ? (
+                  <img
+                    src={clip.thumbnailUrl}
+                    className="w-full h-full object-contain bg-black/5 group-hover:scale-105 transition-transform duration-300"
+                    alt="클립 썸네일"
+                  />
                 ) : (
                   <div className="flex items-center justify-center h-full text-gray-300">
                     <Video className="w-8 h-8 opacity-50" />
                   </div>
                 )}
                 
-                {/* 재생 버튼 오버레이 (마우스 올렸을 때) */}
-                <div className="absolute inset-0 bg-black/10 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                   <div className="w-8 h-8 bg-white/90 rounded-full flex items-center justify-center pl-1 shadow-sm">
-                     <div className="w-0 h-0 border-t-[4px] border-t-transparent border-l-[6px] border-l-black border-b-[4px] border-b-transparent"></div>
-                   </div>
-                </div>
+                {/* 영상일 때만 재생 버튼 오버레이 */}
+                {clip.mediaType === "video" && (
+                  <div className="absolute inset-0 bg-black/10 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                    <div className="w-8 h-8 bg-white/90 rounded-full flex items-center justify-center pl-1 shadow-sm">
+                      <div className="w-0 h-0 border-t-[4px] border-t-transparent border-l-[6px] border-l-black border-b-[4px] border-b-transparent"></div>
+                    </div>
+                  </div>
+                )}
+
+                {clip.mediaType === "video" && (
+                  <div className="absolute bottom-2 right-2 bg-black/70 text-white text-[11px] font-semibold px-2 py-1 rounded-md">
+                    {clip.durationLabel ?? "0:00"}
+                  </div>
+                )}
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </Card>

--- a/Playproof/src/features/team/components/ClipList.tsx
+++ b/Playproof/src/features/team/components/ClipList.tsx
@@ -8,9 +8,15 @@ interface Props {
   clips: Clip[];
   onViewAll?: () => void;
   onSelectClip?: (clip: Clip, index: number) => void;
+  viewAllLabel?: string;
 }
 
-export const ClipList: React.FC<Props> = ({ clips, onViewAll, onSelectClip }) => {
+export const ClipList: React.FC<Props> = ({
+  clips,
+  onViewAll,
+  onSelectClip,
+  viewAllLabel = "전체보기",
+}) => {
   return (
     <section className="flex-1">
       {/* 헤더 (박스 바깥) */}
@@ -21,7 +27,7 @@ export const ClipList: React.FC<Props> = ({ clips, onViewAll, onSelectClip }) =>
           onClick={onViewAll}
           className="text-xs text-gray-500 hover:text-gray-900 flex items-center hover:underline"
         >
-          전체보기
+          {viewAllLabel}
         </button>
       </div>
       

--- a/Playproof/src/features/team/components/ScheduleList.tsx
+++ b/Playproof/src/features/team/components/ScheduleList.tsx
@@ -1,22 +1,23 @@
-//src/features/team/components/ScheduleList.tsx
+// src/features/team/components/ScheduleList.tsx
 import React from 'react';
-import { Plus, Users } from 'lucide-react';
-import type { Schedule } from '@/types';
+import { Plus } from 'lucide-react';
+import type { Schedule } from '@/features/team/types/types';
 import { Card } from '@/components/ui/Card';
+import { ScheduleItem } from '@/features/team/components/azit/schedule/ScheduleItem';
 
 interface Props {
   schedules: Schedule[];
+  currentUserId: string;
 }
 
-export const ScheduleList: React.FC<Props> = ({ schedules }) => {
+export const ScheduleList: React.FC<Props> = ({ schedules, currentUserId }) => {
   return (
     <section>
       <div className="flex justify-between items-center mb-2 px-1">
         <h3 className="font-bold text-base text-gray-900">Schedule</h3>
       </div>
-      
+
       <Card>
-        {/* 정기 매칭 일정 헤더 */}
         <div className="flex justify-between items-center p-4 border-b border-gray-100">
           <h4 className="font-bold text-sm text-gray-800">정기 매칭 일정</h4>
           <button className="hover:bg-gray-100 p-1 rounded transition">
@@ -24,79 +25,14 @@ export const ScheduleList: React.FC<Props> = ({ schedules }) => {
           </button>
         </div>
 
-        {/* 일정 리스트 */}
-        <div className="p-4 space-y-6">
-          {schedules.map((sch, index) => {
-            const isFirstItem = index === 0;
-
-            return (
-              <div key={sch.id} className="relative">
-                <div className="flex gap-3 mb-3">
-                  {/* 날짜 뱃지 */}
-                  {isFirstItem ? (
-                    <div className="border border-gray-300 rounded-lg w-12 h-12 flex flex-col items-center justify-center shrink-0 bg-white">
-                      <span className="text-[10px] font-medium text-gray-500">{sch.dateStr.split(' ')[0]}</span>
-                      <span className="text-sm font-bold text-gray-900">{sch.dateStr.split(' ')[1]}</span>
-                    </div>
-                  ) : null}
-
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-bold text-gray-900 text-base">{sch.timeStr}</span>
-                      {!isFirstItem && sch.fullDate && (
-                        <span className="text-sm text-gray-500 font-medium">
-                          {sch.fullDate.getFullYear()}.{sch.fullDate.getMonth() + 1}.{sch.fullDate.getDate()}
-                        </span>
-                      )}
-                    </div>
-                    
-                    <div className="text-sm text-gray-600 mb-2 font-medium">{sch.title}</div>
-                    
-                    <div className="flex -space-x-1.5 mb-3">
-                      {sch.participants.map((p, idx) => (
-                        <div
-                          key={idx}
-                          className="w-7 h-7 rounded-full bg-gray-100 border-2 border-white overflow-hidden flex items-center justify-center"
-                        >
-                          {p.user?.avatarUrl ? (
-                            <img
-                              src={p.user.avatarUrl}
-                              alt=""
-                              className="w-full h-full object-cover"
-                            />
-                          ) : (
-                            <div className="w-full h-full bg-gray-200" />
-                          )}
-                        </div>
-                      ))}
-                      {sch.needMembers && (
-                         <div className="w-7 h-7 rounded-full bg-gray-100 border-2 border-white flex items-center justify-center text-gray-400">
-                           <Plus className="w-3 h-3" />
-                         </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {sch.isCompleted ? (
-                   <button className="w-full bg-gray-100 text-gray-500 py-2 rounded text-xs font-medium">완료</button>
-                ) : sch.needMembers ? (
-                   <button className="w-full border border-gray-200 text-gray-600 py-2 rounded text-xs font-medium flex items-center justify-center gap-1 hover:bg-gray-50">
-                     <Users className="w-3 h-3" /> 추가 게이머 찾기
-                   </button>
-                ) : (
-                  <div className="flex gap-2">
-                    <button className="flex-1 bg-gray-100 text-gray-800 py-2 rounded text-xs font-bold hover:bg-gray-200">참여</button>
-                    <button className="flex-1 bg-gray-200 text-gray-600 py-2 rounded text-xs font-bold hover:bg-gray-300">불참</button>
-                  </div>
-                )}
-                
-                {index < schedules.length - 1 && (
-                  <div className="absolute -bottom-3 w-full h-px bg-gray-100"></div>
-                )}
-              </div>
-            );
-          })}
+        <div className="p-4 space-y-4">
+          {schedules.map((schedule) => (
+            <ScheduleItem
+              key={schedule.id}
+              schedule={schedule}
+              currentUserId={currentUserId}
+            />
+          ))}
         </div>
       </Card>
     </section>

--- a/Playproof/src/features/team/components/azit/AzitCreateModal.tsx
+++ b/Playproof/src/features/team/components/azit/AzitCreateModal.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { Camera, X } from "lucide-react";
+
+export type AzitCreateData = {
+  name: string;
+  iconUrl?: string;
+};
+
+type AzitCreateModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (data: AzitCreateData) => void;
+};
+
+export const AzitCreateModal: React.FC<AzitCreateModalProps> = ({
+  open,
+  onClose,
+  onCreate,
+}) => {
+  const [name, setName] = React.useState("");
+  const [imageFile, setImageFile] = React.useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = React.useState<string>("");
+  const fileRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setName("");
+    setImageFile(null);
+    setPreviewUrl("");
+  }, [open]);
+
+  React.useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  if (!open) return null;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setImageFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+    e.target.value = "";
+  };
+
+  const handleCreate = () => {
+    if (!name.trim()) return;
+    onCreate({
+      name: name.trim(),
+      iconUrl: previewUrl || undefined,
+    });
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[120] bg-black/30" onClick={onClose} />
+      <div className="fixed inset-0 z-[121] flex items-center justify-center px-4">
+        <div className="w-full max-w-[420px] bg-white rounded-[24px] shadow-2xl border border-gray-100 p-8 relative">
+          <button
+            onClick={onClose}
+            className="absolute right-5 top-5 text-gray-400 hover:text-gray-600"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          <h2 className="text-2xl font-extrabold text-center text-gray-900">아지트 생성</h2>
+
+          <div className="mt-8 flex flex-col items-center gap-6">
+            <button
+              type="button"
+              onClick={() => fileRef.current?.click()}
+              className="w-[120px] h-[120px] rounded-2xl border-2 border-dashed border-gray-300 flex items-center justify-center text-gray-400 hover:border-gray-400 transition-colors overflow-hidden"
+            >
+              {previewUrl ? (
+                <img src={previewUrl} alt="아지트 이미지" className="w-full h-full object-cover" />
+              ) : (
+                <Camera className="w-7 h-7" />
+              )}
+            </button>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+
+            <div className="w-full">
+              <label className="text-[15px] font-bold text-gray-900">아지트 이름</label>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="아지트 이름을 입력하세요"
+                className="mt-2 w-full h-12 rounded-xl bg-gray-100 px-4 text-sm focus:outline-none focus:ring-2 focus:ring-gray-300"
+                maxLength={20}
+              />
+            </div>
+
+            <div className="w-full flex gap-4 pt-2">
+              <button
+                onClick={onClose}
+                className="flex-1 h-12 rounded-xl bg-gray-100 text-gray-700 font-semibold hover:bg-gray-200 transition-colors"
+              >
+                취소하기
+              </button>
+              <button
+                onClick={handleCreate}
+                disabled={!name.trim()}
+                className={`flex-1 h-12 rounded-xl font-semibold transition-colors ${
+                  name.trim()
+                    ? "bg-gray-900 text-white hover:bg-black"
+                    : "bg-gray-200 text-gray-400 cursor-not-allowed"
+                }`}
+              >
+                만들기
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/Playproof/src/features/team/components/azit/AzitCreateModal.tsx
+++ b/Playproof/src/features/team/components/azit/AzitCreateModal.tsx
@@ -18,14 +18,12 @@ export const AzitCreateModal: React.FC<AzitCreateModalProps> = ({
   onCreate,
 }) => {
   const [name, setName] = React.useState("");
-  const [imageFile, setImageFile] = React.useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = React.useState<string>("");
   const fileRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
     if (!open) return;
     setName("");
-    setImageFile(null);
     setPreviewUrl("");
   }, [open]);
 
@@ -41,7 +39,6 @@ export const AzitCreateModal: React.FC<AzitCreateModalProps> = ({
     const file = e.target.files?.[0];
     if (!file) return;
     if (previewUrl) URL.revokeObjectURL(previewUrl);
-    setImageFile(file);
     setPreviewUrl(URL.createObjectURL(file));
     e.target.value = "";
   };

--- a/Playproof/src/features/team/components/azit/AzitNavigation.tsx
+++ b/Playproof/src/features/team/components/azit/AzitNavigation.tsx
@@ -10,14 +10,14 @@ interface AzitNavigationProps {
   onOpenCreate: () => void;
 }
 
-export const AzitNavigation: React.FC<AzitNavigationProps> = ({ 
-  azits, 
-  selectedId, 
+export const AzitNavigation: React.FC<AzitNavigationProps> = ({
+  azits,
+  selectedId,
   onSelect,
   onOpenCreate,
 }) => {
   return (
-    <div className="flex items-center gap-3 px-6 py-4 bg-white">
+    <div className="flex items-center gap-3 px-4 sm:px-6 py-4 bg-white overflow-x-auto">
       {azits.map((azit) => (
         <button
           key={azit.id}

--- a/Playproof/src/features/team/components/azit/AzitNavigation.tsx
+++ b/Playproof/src/features/team/components/azit/AzitNavigation.tsx
@@ -7,12 +7,14 @@ interface AzitNavigationProps {
   azits: Azit[];
   selectedId: number;
   onSelect: (id: number) => void;
+  onOpenCreate: () => void;
 }
 
 export const AzitNavigation: React.FC<AzitNavigationProps> = ({ 
   azits, 
   selectedId, 
-  onSelect 
+  onSelect,
+  onOpenCreate,
 }) => {
   return (
     <div className="flex items-center gap-3 px-6 py-4 bg-white">
@@ -38,7 +40,7 @@ export const AzitNavigation: React.FC<AzitNavigationProps> = ({
       ))}
       <button 
         className="w-14 h-14 rounded-2xl border-2 border-dashed border-gray-300 flex items-center justify-center text-gray-400 hover:border-gray-500 transition-colors shrink-0"
-        onClick={() => alert('아지트 생성')}
+        onClick={onOpenCreate}
       >
         <Plus className="w-6 h-6" />
       </button>

--- a/Playproof/src/features/team/components/azit/LeftPanel.tsx
+++ b/Playproof/src/features/team/components/azit/LeftPanel.tsx
@@ -107,7 +107,7 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({
 
 
   return (
-    <aside className="w-[340px] flex flex-col gap-6 pr-2 overflow-y-auto pb-10 shrink-0 custom-scrollbar">
+    <aside className="w-full lg:w-[340px] flex flex-col gap-6 pr-0 lg:pr-2 overflow-visible lg:overflow-y-auto pb-10 shrink-0 custom-scrollbar">
       
       {/* 1. 스케줄 섹션 (건드리지 않음) */}
       <section>

--- a/Playproof/src/features/team/components/azit/LeftPanel.tsx
+++ b/Playproof/src/features/team/components/azit/LeftPanel.tsx
@@ -2,16 +2,16 @@
 import React from 'react';
 import { Plus, Volume2, Mic } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
-import type { User } from '@/types';
-
-import type { Schedule } from '@/types';
+import type { User, Schedule } from '@/types';
 
 interface LeftPanelProps {
   members: User[];
   schedules?: Schedule[];
+  // ✅ 수정: 이벤트를 통해 '기준이 될 요소(HTMLElement)'를 전달받도록 변경
+  onAddSchedule?: (target: HTMLElement) => void;
 }
 
-export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [] }) => {
+export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [], onAddSchedule }) => {
   const mainSchedule = schedules[0];
   const secondarySchedule = schedules[1];
   const tertiarySchedule = schedules[2];
@@ -20,13 +20,29 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [] })
     d ? d.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '';
   const formatTime = (d?: Date) =>
     d ? d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }) : '';
+
   return (
     <aside className="w-[340px] flex flex-col gap-6 pr-2 overflow-y-auto pb-10 shrink-0 custom-scrollbar">
       
       {/* 스케줄 섹션 */}
       <section>
-        <h2 className="text-lg font-bold text-gray-900 mb-3 px-1">스케줄</h2>
-        
+        {/* ✅ 헤더 영역: 이 div가 모달의 위치 기준점이 됩니다. */}
+        <div className="flex justify-between items-center mb-3 px-1 relative">
+          <h2 className="text-lg font-bold text-gray-900">스케줄</h2>
+          <button 
+            onClick={(e) => {
+              // ✅ 핵심 수정: 버튼이 아닌 '헤더 전체 영역(부모 div)'을 anchor로 전달
+              // e.currentTarget = button, parentElement = div.flex...
+              if (onAddSchedule && e.currentTarget.parentElement) {
+                onAddSchedule(e.currentTarget.parentElement);
+              }
+            }}
+            className="hover:bg-gray-100 rounded-full p-1 transition-colors"
+            type="button"
+          >
+            <Plus className="w-4 h-4 text-gray-400" />
+          </button>
+        </div>
         
         <Card className="overflow-hidden border border-gray-200 shadow-sm rounded-xl bg-white">
           
@@ -91,7 +107,7 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [] })
             </div>
           </div>
 
-          {/* 하위 일정  */}
+          {/* 하위 일정 1 */}
           <div className="p-4 border-b border-gray-100 last:border-0">
              <div className="flex items-center gap-2 mb-1">
                 <span className="font-bold text-gray-900 text-base">
@@ -140,7 +156,7 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [] })
         </Card>
       </section>
 
-      {/*음성 채팅 섹션 */}
+      {/* 음성 채팅 섹션 */}
       <section>
         <div className="flex justify-between items-center mb-2 px-1">
           <h2 className="text-lg font-bold text-gray-900">음성 채팅</h2>

--- a/Playproof/src/features/team/components/azit/LeftPanel.tsx
+++ b/Playproof/src/features/team/components/azit/LeftPanel.tsx
@@ -1,190 +1,82 @@
 // src/features/team/components/azit/LeftPanel.tsx
 import React from 'react';
 import { Plus, Volume2, Mic } from 'lucide-react';
-import { Card } from '@/components/ui/Card';
-import type { User, Schedule } from '@/types';
+import type { User, Schedule } from '@/features/team/types/types';
+import { ScheduleItem } from '@/features/team/components/azit/schedule/ScheduleItem';
 
 interface LeftPanelProps {
   members: User[];
   schedules?: Schedule[];
-  // ✅ 수정: 이벤트를 통해 '기준이 될 요소(HTMLElement)'를 전달받도록 변경
+  currentUserId: string;
   onAddSchedule?: (target: HTMLElement) => void;
+  // [추가] 상태 변경 핸들러 타입 정의
+  onStatusChange?: (scheduleId: string, newStatus: 'JOIN' | 'DECLINE') => void;
 }
 
-export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [], onAddSchedule }) => {
-  const mainSchedule = schedules[0];
-  const secondarySchedule = schedules[1];
-  const tertiarySchedule = schedules[2];
-
-  const formatDate = (d?: Date) =>
-    d ? d.toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '';
-  const formatTime = (d?: Date) =>
-    d ? d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' }) : '';
-
+export const LeftPanel: React.FC<LeftPanelProps> = ({ 
+  members, 
+  schedules = [], 
+  currentUserId,
+  onAddSchedule,
+  onStatusChange
+}) => {
   return (
     <aside className="w-[340px] flex flex-col gap-6 pr-2 overflow-y-auto pb-10 shrink-0 custom-scrollbar">
       
-      {/* 스케줄 섹션 */}
       <section>
-        {/* ✅ 헤더 영역: 이 div가 모달의 위치 기준점이 됩니다. */}
         <div className="flex justify-between items-center mb-3 px-1 relative">
           <h2 className="text-lg font-bold text-gray-900">스케줄</h2>
           <button 
-            onClick={(e) => {
-              // ✅ 핵심 수정: 버튼이 아닌 '헤더 전체 영역(부모 div)'을 anchor로 전달
-              // e.currentTarget = button, parentElement = div.flex...
-              if (onAddSchedule && e.currentTarget.parentElement) {
-                onAddSchedule(e.currentTarget.parentElement);
-              }
-            }}
+            onClick={(e) => onAddSchedule && e.currentTarget.parentElement && onAddSchedule(e.currentTarget.parentElement)}
             className="hover:bg-gray-100 rounded-full p-1 transition-colors"
-            type="button"
           >
             <Plus className="w-4 h-4 text-gray-400" />
           </button>
         </div>
         
-        <Card className="overflow-hidden border border-gray-200 shadow-sm rounded-xl bg-white">
-          
-          {/* 정기 매칭 일정 헤더 */}
-          <div className="px-4 py-3 border-b border-gray-100 flex justify-between items-center bg-white">
+        <div className="mb-2 px-1">
             <span className="font-bold text-gray-800 text-sm">정기 매칭 일정</span>
-            <button className="text-gray-400 hover:bg-gray-100 p-1 rounded">
-               <span className="sr-only">옵션</span>
-               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
-            </button>
-          </div>
-          
-          {/* 메인 일정 (카운트다운) */}
-          <div className="p-4 border-b border-gray-100">
-            <div className="flex gap-4 mb-4">
-               {/* 날짜 배지 */}
-               <div className="flex flex-col items-center justify-center bg-gray-50 border border-gray-100 rounded-xl w-[52px] h-[52px] shrink-0">
-                  <span className="text-[11px] text-gray-500 font-medium uppercase leading-none mb-0.5">
-                    {mainSchedule ? mainSchedule.date.toLocaleDateString('en-US', { weekday: 'short' }) : '--'}
-                  </span>
-                  <span className="text-xl font-bold text-gray-900 leading-none">
-                    {mainSchedule ? mainSchedule.date.getDate() : '--'}
-                  </span>
-               </div>
-               
-               {/* 내용 */}
-               <div className="flex-1 min-w-0">
-                 <div className="flex items-center gap-2 mb-1">
-                   <span className="text-lg font-bold text-gray-900 leading-none">
-                     {formatTime(mainSchedule?.date) || '--:--'}
-                   </span>
-                   <Volume2 className="w-4 h-4 text-gray-400" />
-                 </div>
-                 <div className="text-sm text-gray-600 font-medium truncate">
-                   {mainSchedule?.title ?? '일정 없음'}
-                 </div>
-                 {/* 아바타 */}
-                 <div className="flex -space-x-1.5 mt-2">
-                    {(mainSchedule?.participants ?? []).slice(0, 3).map((_, i) => (
-                      <div key={i} className="w-6 h-6 rounded-full bg-gray-200 border-2 border-white" />
-                    ))}
-                 </div>
-               </div>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {schedules.length > 0 ? (
+            schedules.map((sch) => (
+              <ScheduleItem 
+                key={sch.id} 
+                schedule={sch} 
+                currentUserId={currentUserId}
+                onStatusChange={onStatusChange}
+              />
+            ))
+          ) : (
+            <div className="p-8 text-center text-gray-400 text-sm bg-white rounded-xl border border-gray-200">
+              등록된 일정이 없습니다.
             </div>
-
-            {/* 타이머 */}
-            <div className="bg-gray-50 rounded-lg py-3 text-center mb-3">
-              <div className="text-[11px] text-gray-500 mb-0.5">매칭완료까지</div>
-              <div className="text-2xl font-black text-gray-900 tabular-nums tracking-tight">
-                1 : 59 : 30
-              </div>
-            </div>
-
-            {/* 버튼 */}
-            <div className="flex gap-2">
-              <button className="flex-1 bg-white border border-gray-200 text-gray-900 py-2 rounded-lg text-xs font-bold hover:bg-gray-50">
-                참여
-              </button>
-              <button className="flex-1 bg-gray-100 text-gray-500 py-2 rounded-lg text-xs font-bold hover:bg-gray-200">
-                불참
-              </button>
-            </div>
-          </div>
-
-          {/* 하위 일정 1 */}
-          <div className="p-4 border-b border-gray-100 last:border-0">
-             <div className="flex items-center gap-2 mb-1">
-                <span className="font-bold text-gray-900 text-base">
-                  {formatTime(secondarySchedule?.date) || '--:--'}
-                </span>
-                <span className="text-xs text-gray-500 font-medium">
-                  {formatDate(secondarySchedule?.date)}
-                </span>
-             </div>
-             <div className="text-sm text-gray-700 font-medium mb-2">
-               {secondarySchedule?.title ?? '일정 없음'}
-             </div>
-             <div className="flex items-center gap-1.5 mb-3">
-                {(secondarySchedule?.participants ?? []).slice(0, 5).map((_, i) => (
-                  <div key={i} className="w-6 h-6 rounded-full bg-gray-200" />
-                ))}
-             </div>
-             <button className="w-full bg-gray-100 text-gray-400 py-2 rounded-lg text-xs font-bold cursor-not-allowed">
-               완료
-             </button>
-          </div>
-          
-          {/* 하위 일정 2 */}
-          <div className="p-4">
-             <div className="flex items-center gap-2 mb-1">
-                <span className="font-bold text-gray-900 text-base">
-                  {formatTime(tertiarySchedule?.date) || '--:--'}
-                </span>
-                <span className="text-xs text-gray-500 font-medium">
-                  {formatDate(tertiarySchedule?.date)}
-                </span>
-             </div>
-             <div className="text-sm text-gray-700 font-medium mb-2">
-               {tertiarySchedule?.title ?? '일정 없음'}
-             </div>
-             <div className="flex items-center gap-1.5 mb-3">
-                {(tertiarySchedule?.participants ?? []).slice(0, 2).map((_, i) => (
-                  <div key={i} className="w-6 h-6 rounded-full bg-gray-200" />
-                ))}
-             </div>
-             <button className="w-full bg-white border border-gray-200 text-gray-600 py-2 rounded-lg text-xs font-bold hover:bg-gray-50 flex items-center justify-center gap-1">
-               <Plus className="w-3 h-3" /> 추가 게이머 찾기
-             </button>
-          </div>
-
-        </Card>
+          )}
+        </div>
       </section>
 
-      {/* 음성 채팅 섹션 */}
+      {/* 나머지 음성 채팅 및 멤버 섹션은 동일하게 유지 */}
       <section>
         <div className="flex justify-between items-center mb-2 px-1">
           <h2 className="text-lg font-bold text-gray-900">음성 채팅</h2>
           <button className="hover:bg-gray-100 rounded-full p-1"><Plus className="w-4 h-4 text-gray-400" /></button>
         </div>
-        
         <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
-          
-          {/* 로비 (일반 음성방) */}
           <div className="px-4 py-3 flex items-center gap-3 border-b border-gray-50 hover:bg-gray-50 cursor-pointer h-12">
             <Volume2 className="w-4 h-4 text-gray-500" />
             <span className="text-sm font-bold text-gray-600">로비</span>
           </div>
-
-          {/* 스크림 룸 (활성 - 참여자 표시) */}
           <div className="bg-gray-50/50 pb-3 border-b border-gray-50">
              <div className="px-4 py-2 flex items-center gap-3 h-10">
                <Volume2 className="w-4 h-4 text-gray-900" />
                <span className="text-sm font-bold text-gray-900">스크림 룸</span>
              </div>
-             {/* 참여자 리스트 (들여쓰기) */}
              <div className="pl-11 pr-4 space-y-2">
-               {/* 유저 1 */}
                <div className="flex items-center gap-2">
                  <div className="w-5 h-5 rounded-full bg-gray-300" />
                  <span className="text-sm text-gray-600 font-medium">레나</span>
                </div>
-               {/* 유저 2 */}
                <div className="flex items-center gap-2">
                  <div className="w-5 h-5 rounded-full bg-gray-300" />
                  <span className="text-sm text-gray-600 font-medium">엘릭</span>
@@ -192,22 +84,9 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ members, schedules = [], o
                </div>
              </div>
           </div>
-
-          {/* 그 아래 다른 채팅방 (팀 채팅) */}
-          <div className="px-4 py-3 flex items-center gap-3 border-b border-gray-50 hover:bg-gray-50 cursor-pointer h-12">
-            <Volume2 className="w-4 h-4 text-gray-400" />
-            <span className="text-sm font-bold text-gray-500">팀 채팅</span>
-          </div>
-          
-           {/* 그 아래 다른 채팅방 (수다방) */}
-           <div className="px-4 py-3 flex items-center gap-3 hover:bg-gray-50 cursor-pointer h-12">
-            <Volume2 className="w-4 h-4 text-gray-400" />
-            <span className="text-sm font-bold text-gray-500">수다방</span>
-          </div>
         </div>
       </section>
 
-      {/* 멤버 섹션 */}
       <section>
         <div className="flex justify-between items-center mb-2 px-1">
           <h2 className="text-lg font-bold text-gray-900">멤버</h2>

--- a/Playproof/src/features/team/components/azit/LeftPanel.tsx
+++ b/Playproof/src/features/team/components/azit/LeftPanel.tsx
@@ -12,6 +12,7 @@ interface LeftPanelProps {
   currentUserId: string;
   onAddSchedule?: (target: HTMLElement) => void;
   onStatusChange?: (scheduleId: string, newStatus: 'JOIN' | 'DECLINE') => void;
+  onFeedback?: (scheduleId: string) => void;
   selectedChatRoom: string;
   onSelectChatRoom: (roomName: string) => void;
   voiceRooms: { id: string; name: string; users: User[] }[];
@@ -30,6 +31,7 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({
   currentUserId,
   onAddSchedule,
   onStatusChange,
+  onFeedback,
   selectedChatRoom,
   onSelectChatRoom,
   voiceRooms,
@@ -131,6 +133,7 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({
                 schedule={sch} 
                 currentUserId={currentUserId}
                 onStatusChange={onStatusChange}
+                onFeedback={onFeedback}
               />
             ))
           ) : (

--- a/Playproof/src/features/team/components/azit/LeftPanel.tsx
+++ b/Playproof/src/features/team/components/azit/LeftPanel.tsx
@@ -1,16 +1,27 @@
-// src/features/team/components/azit/LeftPanel.tsx
-import React from 'react';
-import { Plus, Volume2, Mic } from 'lucide-react';
+import React, { useState } from 'react';
+import { Plus, Volume2, Mic, MessageSquare, Pencil, Trash2, Check, X } from 'lucide-react';
 import type { User, Schedule } from '@/features/team/types/types';
 import { ScheduleItem } from '@/features/team/components/azit/schedule/ScheduleItem';
+// ✅ 모달 Import
+import { ChatRoomCreateModal } from './chat/ChatRoomCreateModal';
+import type { ChatRoomCreateData } from './chat/ChatRoomCreateModal';
 
 interface LeftPanelProps {
   members: User[];
   schedules?: Schedule[];
   currentUserId: string;
   onAddSchedule?: (target: HTMLElement) => void;
-  // [추가] 상태 변경 핸들러 타입 정의
   onStatusChange?: (scheduleId: string, newStatus: 'JOIN' | 'DECLINE') => void;
+  selectedChatRoom: string;
+  onSelectChatRoom: (roomName: string) => void;
+  voiceRooms: { id: string; name: string; users: User[] }[];
+  onJoinVoiceRoom: (roomId: string) => void;
+  textRooms: string[];
+  onCreateChatRoom: (name: string, type: "TEXT" | "VOICE") => void;
+  onRenameVoiceRoom: (roomId: string, nextName: string) => void;
+  onDeleteVoiceRoom: (roomId: string) => void;
+  onRenameChatRoom: (roomName: string, nextName: string) => void;
+  onDeleteChatRoom: (roomName: string) => void;
 }
 
 export const LeftPanel: React.FC<LeftPanelProps> = ({ 
@@ -18,11 +29,85 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({
   schedules = [], 
   currentUserId,
   onAddSchedule,
-  onStatusChange
+  onStatusChange,
+  selectedChatRoom,
+  onSelectChatRoom,
+  voiceRooms,
+  onJoinVoiceRoom,
+  textRooms,
+  onCreateChatRoom,
+  onRenameVoiceRoom,
+  onDeleteVoiceRoom,
+  onRenameChatRoom,
+  onDeleteChatRoom
 }) => {
+  // ✅ 모달 상태 관리
+  const [chatCreateAnchorEl, setChatCreateAnchorEl] = useState<HTMLElement | null>(null);
+  const [editingRoom, setEditingRoom] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [editingVoiceId, setEditingVoiceId] = useState<string | null>(null);
+  const [editingVoiceName, setEditingVoiceName] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmTitle, setConfirmTitle] = useState("삭제 확인");
+  const [confirmDescription, setConfirmDescription] = useState("");
+  const confirmActionRef = React.useRef<() => void>(() => {});
+
+  // ✅ 채팅방 생성 핸들러 (API 호출 로직 추가할 곳)
+  const handleCreateChatRoom = (data: ChatRoomCreateData) => {
+    console.log("생성할 채팅방 데이터:", data);
+    // TODO: API 호출 예시 -> createChatRoomMutation.mutate(data);
+    onCreateChatRoom(data.name, data.type);
+  };
+
+  const startEditingRoom = (roomName: string) => {
+    setEditingRoom(roomName);
+    setEditingName(roomName);
+  };
+
+  const cancelEditingRoom = () => {
+    setEditingRoom(null);
+    setEditingName("");
+  };
+
+  const submitEditingRoom = () => {
+    if (!editingRoom) return;
+    onRenameChatRoom(editingRoom, editingName);
+    cancelEditingRoom();
+  };
+
+  const startEditingVoice = (roomId: string, roomName: string) => {
+    setEditingVoiceId(roomId);
+    setEditingVoiceName(roomName);
+  };
+
+  const cancelEditingVoice = () => {
+    setEditingVoiceId(null);
+    setEditingVoiceName("");
+  };
+
+  const submitEditingVoice = () => {
+    if (!editingVoiceId) return;
+    onRenameVoiceRoom(editingVoiceId, editingVoiceName);
+    cancelEditingVoice();
+  };
+
+  const openConfirm = (title: string, description: string, onConfirm: () => void) => {
+    setConfirmTitle(title);
+    setConfirmDescription(description);
+    confirmActionRef.current = onConfirm;
+    setConfirmOpen(true);
+  };
+
+  const handleConfirm = () => {
+    confirmActionRef.current();
+    setConfirmOpen(false);
+  };
+
+
   return (
     <aside className="w-[340px] flex flex-col gap-6 pr-2 overflow-y-auto pb-10 shrink-0 custom-scrollbar">
       
+      {/* 1. 스케줄 섹션 (건드리지 않음) */}
       <section>
         <div className="flex justify-between items-center mb-3 px-1 relative">
           <h2 className="text-lg font-bold text-gray-900">스케줄</h2>
@@ -56,37 +141,224 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({
         </div>
       </section>
 
-      {/* 나머지 음성 채팅 및 멤버 섹션은 동일하게 유지 */}
+      {/* 2. 채팅 섹션 */}
       <section>
         <div className="flex justify-between items-center mb-2 px-1">
-          <h2 className="text-lg font-bold text-gray-900">음성 채팅</h2>
-          <button className="hover:bg-gray-100 rounded-full p-1"><Plus className="w-4 h-4 text-gray-400" /></button>
+          <h2 className="text-lg font-bold text-gray-900">채팅</h2>
+          <button
+            type="button"
+            onClick={(e) =>
+              setChatCreateAnchorEl(
+                e.currentTarget.parentElement ?? e.currentTarget
+              )
+            }
+            className="hover:bg-gray-100 rounded-full p-1 transition-colors"
+          >
+            <Plus className="w-4 h-4 text-gray-400" />
+          </button>
         </div>
+
         <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
-          <div className="px-4 py-3 flex items-center gap-3 border-b border-gray-50 hover:bg-gray-50 cursor-pointer h-12">
-            <Volume2 className="w-4 h-4 text-gray-500" />
-            <span className="text-sm font-bold text-gray-600">로비</span>
+          <div className="px-4 py-3 border-b border-gray-100">
+            <div className="text-xs font-bold text-gray-500">음성 채팅</div>
           </div>
-          <div className="bg-gray-50/50 pb-3 border-b border-gray-50">
-             <div className="px-4 py-2 flex items-center gap-3 h-10">
-               <Volume2 className="w-4 h-4 text-gray-900" />
-               <span className="text-sm font-bold text-gray-900">스크림 룸</span>
-             </div>
-             <div className="pl-11 pr-4 space-y-2">
-               <div className="flex items-center gap-2">
-                 <div className="w-5 h-5 rounded-full bg-gray-300" />
-                 <span className="text-sm text-gray-600 font-medium">레나</span>
-               </div>
-               <div className="flex items-center gap-2">
-                 <div className="w-5 h-5 rounded-full bg-gray-300" />
-                 <span className="text-sm text-gray-600 font-medium">엘릭</span>
-                 <Mic className="w-3 h-3 text-red-400 ml-auto" />
-               </div>
-             </div>
+          {voiceRooms.map((room, index) => (
+            <div
+              key={room.id}
+              className={index === 0 ? "border-b border-gray-50" : "bg-gray-50/50 pb-3 border-b border-gray-100"}
+            >
+              <div className="w-full px-4 py-2 flex items-center gap-3 h-12">
+                <button
+                  type="button"
+                  onClick={() => onJoinVoiceRoom(room.id)}
+                  className="flex items-center gap-3 flex-1 min-w-0"
+                >
+                  <Volume2 className={`w-4 h-4 ${index === 0 ? "text-gray-500" : "text-gray-900"}`} />
+                  {editingVoiceId === room.id ? (
+                    <input
+                      value={editingVoiceName}
+                      onChange={(e) => setEditingVoiceName(e.target.value)}
+                      className="h-8 px-2 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-gray-400 w-full"
+                      maxLength={20}
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          submitEditingVoice();
+                        }
+                        if (e.key === "Escape") {
+                          cancelEditingVoice();
+                        }
+                      }}
+                    />
+                  ) : (
+                    <span className={`text-sm font-bold truncate ${index === 0 ? "text-gray-600" : "text-gray-900"}`}>
+                      {room.name}
+                    </span>
+                  )}
+                </button>
+                {editingVoiceId === room.id ? (
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={submitEditingVoice}
+                      className="p-1 rounded-md hover:bg-blue-100 text-blue-600"
+                    >
+                      <Check className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEditingVoice}
+                      className="p-1 rounded-md hover:bg-gray-100 text-gray-500"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => startEditingVoice(room.id, room.name)}
+                      className="p-1 rounded-md hover:bg-gray-100 text-gray-400 hover:text-gray-600"
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openConfirm(
+                          "음성 채팅방 삭제",
+                          `"${room.name}" 음성 채팅방을 삭제할까요?`,
+                          () => onDeleteVoiceRoom(room.id)
+                        )
+                      }
+                      disabled={voiceRooms.length <= 1}
+                      className={`p-1 rounded-md ${
+                        voiceRooms.length <= 1
+                          ? "text-gray-200 cursor-not-allowed"
+                          : "hover:bg-red-50 text-gray-400 hover:text-red-500"
+                      }`}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                )}
+              </div>
+              <div className="pl-11 pr-4 space-y-2 pb-3">
+                {room.users.length === 0 ? (
+                  <div className="text-xs text-gray-400">참여자가 없습니다.</div>
+                ) : (
+                  room.users.map((user) => (
+                    <div key={user.id} className="flex items-center gap-2">
+                      <div className="w-5 h-5 rounded-full bg-gray-300" />
+                      <span className="text-sm text-gray-600 font-medium">{user.nickname}</span>
+                      {String(user.id) === String(currentUserId) && (
+                        <Mic className="w-3 h-3 text-red-400 ml-auto" />
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          ))}
+
+          <div className="px-4 py-3 border-b border-gray-100">
+            <div className="text-xs font-bold text-gray-500">일반 채팅</div>
           </div>
+          {textRooms.map((room) => {
+            const isSelected = selectedChatRoom === room;
+            const isEditing = editingRoom === room;
+            return (
+              <div
+                key={room}
+                className={`px-4 py-2 flex items-center gap-3 w-full h-12 transition-colors ${
+                  isSelected ? "bg-blue-50 text-blue-700" : "hover:bg-gray-50 text-gray-600"
+                } ${room === "자유 대화" ? "border-b border-gray-50" : ""}`}
+              >
+                <div className="flex items-center gap-3 flex-1 min-w-0">
+                  <MessageSquare
+                    className={`w-4 h-4 ${isSelected ? "text-blue-600" : "text-gray-500"}`}
+                  />
+                  {isEditing ? (
+                    <input
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      className="h-8 px-2 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-gray-400 w-full"
+                      maxLength={20}
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          submitEditingRoom();
+                        }
+                        if (e.key === "Escape") {
+                          cancelEditingRoom();
+                        }
+                      }}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => onSelectChatRoom(room)}
+                      className={`text-sm font-bold truncate text-left flex-1 ${
+                        isSelected ? "text-blue-700" : "text-gray-600"
+                      }`}
+                    >
+                      {room}
+                    </button>
+                  )}
+                </div>
+                {isEditing ? (
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={submitEditingRoom}
+                      className="p-1 rounded-md hover:bg-blue-100 text-blue-600"
+                    >
+                      <Check className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelEditingRoom}
+                      className="p-1 rounded-md hover:bg-gray-100 text-gray-500"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => startEditingRoom(room)}
+                      className="p-1 rounded-md hover:bg-gray-100 text-gray-400 hover:text-gray-600"
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openConfirm(
+                          "채팅방 삭제",
+                          `"${room}" 채팅방을 삭제할까요?`,
+                          () => onDeleteChatRoom(room)
+                        )
+                      }
+                      disabled={textRooms.length <= 1}
+                      className={`p-1 rounded-md ${
+                        textRooms.length <= 1
+                          ? "text-gray-200 cursor-not-allowed"
+                          : "hover:bg-red-50 text-gray-400 hover:text-red-500"
+                      }`}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       </section>
 
+      {/* 3. 멤버 섹션 (기존 유지) */}
       <section>
         <div className="flex justify-between items-center mb-2 px-1">
           <h2 className="text-lg font-bold text-gray-900">멤버</h2>
@@ -107,6 +379,39 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({
           ))}
         </div>
       </section>
+
+      {/* ✅ 모달 컴포넌트 렌더링 (Portal 사용으로 위치 상관 없음) */}
+      <ChatRoomCreateModal 
+        anchorEl={chatCreateAnchorEl}
+        onClose={() => setChatCreateAnchorEl(null)}
+        onCreate={handleCreateChatRoom}
+      />
+
+      {confirmOpen && (
+        <>
+          <div className="fixed inset-0 z-[110] bg-black/30" onClick={() => setConfirmOpen(false)} />
+          <div className="fixed inset-0 z-[111] flex items-center justify-center px-4">
+            <div className="w-full max-w-[360px] bg-white rounded-2xl shadow-xl border border-gray-100 p-6">
+              <h3 className="text-lg font-bold text-gray-900">{confirmTitle}</h3>
+              <p className="text-sm text-gray-500 mt-2">{confirmDescription}</p>
+              <div className="flex gap-3 mt-6">
+                <button
+                  className="flex-1 h-10 rounded-xl bg-gray-100 text-gray-700 font-semibold hover:bg-gray-200 transition-colors"
+                  onClick={() => setConfirmOpen(false)}
+                >
+                  취소
+                </button>
+                <button
+                  className="flex-1 h-10 rounded-xl bg-gray-900 text-white font-semibold hover:bg-black transition-colors"
+                  onClick={handleConfirm}
+                >
+                  삭제
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
 
     </aside>
   );

--- a/Playproof/src/features/team/components/azit/MainPanel.tsx
+++ b/Playproof/src/features/team/components/azit/MainPanel.tsx
@@ -55,7 +55,7 @@ export const MainPanel: React.FC<MainPanelProps> = ({
   }, [activeMedia, navigate]);
 
   return (
-    <main className="flex-1 flex flex-col min-w-[400px] h-full">
+    <main className="flex-1 flex flex-col w-full min-w-0 lg:min-w-[400px] h-auto lg:h-full">
       {/* 헤더 */}
       <div className="flex-none h-12 flex items-center gap-2 mb-2 px-1">
         <h2 className="text-lg font-bold text-gray-900">{roomName}</h2>

--- a/Playproof/src/features/team/components/azit/MainPanel.tsx
+++ b/Playproof/src/features/team/components/azit/MainPanel.tsx
@@ -1,19 +1,63 @@
 // src/features/team/components/azit/MainPanel.tsx
 import React from 'react';
+import { useNavigate } from "react-router-dom";
 import { Plus, Trash2, Send, Paperclip } from 'lucide-react';
-import { useAzitChat } from '@/features/team/hooks/useAzitChat'; 
+import { useAzitChat } from '@/features/team/hooks/useAzitChat';
 
-export const MainPanel: React.FC = () => {
+type ChatMessage = {
+  id: string;
+  author: string;
+  content: string;
+  createdAt: string;
+  media?: { url: string; type: "image" | "video" }[];
+};
+
+type MainPanelProps = {
+  roomName: string;
+  messages: ChatMessage[];
+  onSendMessage: (roomName: string, content: string, files: File[]) => void;
+  currentUserName: string;
+};
+
+export const MainPanel: React.FC<MainPanelProps> = ({
+  roomName,
+  messages,
+  onSendMessage,
+  currentUserName,
+}) => {
+  const [activeMedia, setActiveMedia] = React.useState<{ url: string; type: "image" | "video" } | null>(null);
+  const navigate = useNavigate();
   const {
-    message, setMessage, previewUrls, fileInputRef,
+    message, setMessage, selectedFiles, previewItems, fileInputRef,
     handleFileSelect, handleRemoveImage, triggerFileInput, sendMessage, hasContent
   } = useAzitChat();
+
+  const handleSend = () => {
+    if (!hasContent) return;
+    onSendMessage(roomName, message, selectedFiles);
+    sendMessage();
+  };
+
+  const handleShareToHighlight = React.useCallback(async () => {
+    if (!activeMedia) return;
+    if (activeMedia.type === "video") {
+      alert("영상 공유는 아직 준비 중이에요.");
+      return;
+    }
+    const response = await fetch(activeMedia.url);
+    const blob = await response.blob();
+    const ext = blob.type.includes("png") ? "png" : "jpg";
+    const file = new File([blob], `highlight-share-${Date.now()}.${ext}`, {
+      type: blob.type || "image/jpeg",
+    });
+    navigate("/community?tab=하이라이트", { state: { shareFiles: [file] } });
+  }, [activeMedia, navigate]);
 
   return (
     <main className="flex-1 flex flex-col min-w-[400px] h-full">
       {/* 헤더 */}
       <div className="flex-none h-12 flex items-center gap-2 mb-2 px-1">
-        <h2 className="text-lg font-bold text-gray-900">팀 채팅</h2>
+        <h2 className="text-lg font-bold text-gray-900">{roomName}</h2>
         <button className="text-gray-400 hover:bg-gray-100 p-0.5 rounded transition-colors">
            <Plus className="w-5 h-5" />
         </button>
@@ -22,17 +66,81 @@ export const MainPanel: React.FC = () => {
       <div className="flex-1 bg-white border border-gray-200 rounded-xl shadow-sm flex flex-col overflow-hidden relative">
         {/* 채팅 영역 */}
         <div className="flex-1 bg-gray-50 p-4 flex flex-col-reverse overflow-y-auto">
-          {/* 메시지 리스트 컴포넌트가 있다면 여기에 위치 */}
-          <div className="text-center text-gray-400 text-sm my-auto">채팅 기록이 없습니다.</div>
+          {messages.length === 0 ? (
+            <div className="text-center text-gray-400 text-sm my-auto">채팅 기록이 없습니다.</div>
+          ) : (
+            messages.map((item) => {
+              const isMine = item.author === currentUserName;
+              return (
+                <div
+                  key={item.id}
+                  className={`flex flex-col gap-2 mb-4 ${isMine ? "items-end" : "items-start"}`}
+                >
+                  <div className="flex items-center gap-2 text-xs text-gray-500">
+                    <span className="font-semibold text-gray-700">{item.author}</span>
+                    <span>{item.createdAt}</span>
+                  </div>
+                  {item.content && (
+                    <div
+                      className={`rounded-xl px-3 py-2 text-sm shadow-sm w-fit max-w-[75%] ${
+                        isMine
+                          ? "bg-blue-500 text-white"
+                          : "bg-white border border-gray-200 text-gray-800"
+                      }`}
+                    >
+                      {item.content}
+                    </div>
+                  )}
+                  {item.media && item.media.length > 0 && (
+                    <div className={`flex gap-2 flex-wrap ${isMine ? "justify-end" : "justify-start"}`}>
+                      {item.media.map((mediaItem, index) =>
+                        mediaItem.type === "video" ? (
+                          <video
+                            key={`${item.id}-media-${index}`}
+                            src={mediaItem.url}
+                            className="w-[160px] h-[120px] object-cover rounded-lg border border-gray-200"
+                            muted
+                            playsInline
+                          />
+                        ) : (
+                          <button
+                            key={`${item.id}-media-${index}`}
+                            type="button"
+                            onClick={() => setActiveMedia(mediaItem)}
+                            className="w-[160px] h-[120px] rounded-lg border border-gray-200 overflow-hidden"
+                          >
+                            <img
+                              src={mediaItem.url}
+                              alt="chat attachment"
+                              className="w-full h-full object-cover"
+                            />
+                          </button>
+                        )
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
         </div>
 
         {/* 이미지 프리뷰 */}
-        {previewUrls.length > 0 && (
+        {previewItems.length > 0 && (
           <div className="flex-none p-4 bg-white border-t border-gray-100">
             <div className="flex gap-3 overflow-x-auto pb-2 custom-scrollbar">
-              {previewUrls.map((url, index) => (
+              {previewItems.map((item, index) => (
                 <div key={index} className="relative shrink-0 w-[160px] h-[120px] bg-gray-100 border border-gray-200 rounded-xl overflow-hidden">
-                  <img src={url} alt="preview" className="w-full h-full object-cover" />
+                  {item.type === "video" ? (
+                    <video
+                      src={item.url}
+                      className="w-full h-full object-cover"
+                      muted
+                      playsInline
+                    />
+                  ) : (
+                    <img src={item.url} alt="preview" className="w-full h-full object-cover" />
+                  )}
                   <button 
                     onClick={() => handleRemoveImage(index)}
                     className="absolute -top-2 -right-2 w-7 h-7 bg-white border border-gray-200 rounded-full flex items-center justify-center text-gray-400 hover:text-red-500 shadow-sm z-10"
@@ -48,7 +156,7 @@ export const MainPanel: React.FC = () => {
         {/* 입력바 */}
         <div className="p-4 bg-white border-t border-gray-100">
            <input 
-             type="file" accept="image/*" multiple
+             type="file" accept="image/*,video/*" multiple
              ref={fileInputRef} onChange={handleFileSelect} className="hidden"
            />
            <div className="relative flex items-center w-full">
@@ -59,12 +167,17 @@ export const MainPanel: React.FC = () => {
                type="text" 
                value={message}
                onChange={(e) => setMessage(e.target.value)}
-               onKeyPress={(e) => e.key === 'Enter' && sendMessage()}
+               onKeyDown={(e) => {
+                 if (e.key !== "Enter") return;
+                 if (e.nativeEvent.isComposing) return;
+                 e.preventDefault();
+                 handleSend();
+               }}
                placeholder="메세지를 입력해주세요."
                className="w-full bg-white border border-gray-200 rounded-lg py-3 pl-10 pr-12 text-sm focus:outline-none focus:border-gray-400"
              />
              <button 
-               onClick={sendMessage}
+               onClick={handleSend}
                disabled={!hasContent}
                className={`absolute right-3 transition-colors ${hasContent ? 'text-blue-500 hover:text-blue-600' : 'text-gray-300'}`}
              >
@@ -73,6 +186,54 @@ export const MainPanel: React.FC = () => {
            </div>
         </div>
       </div>
+
+      {activeMedia && (
+        <>
+          <div
+            className="fixed inset-0 z-[130] bg-black/60"
+            onClick={() => setActiveMedia(null)}
+          />
+          <div className="fixed inset-0 z-[131] flex items-center justify-center px-6">
+            <div className="w-full max-w-[960px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-4">
+              <div className="flex items-center justify-between mb-3 px-2">
+                <h3 className="text-base font-bold text-gray-900">미디어 보기</h3>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleShareToHighlight}
+                    className="text-sm text-gray-500 hover:text-gray-900"
+                  >
+                    공유
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setActiveMedia(null)}
+                    className="text-sm text-gray-500 hover:text-gray-900"
+                  >
+                    닫기
+                  </button>
+                </div>
+              </div>
+              <div className="w-full aspect-video bg-black rounded-xl overflow-hidden flex items-center justify-center">
+                {activeMedia.type === "video" ? (
+                  <video
+                    src={activeMedia.url}
+                    className="w-full h-full object-contain"
+                    controls
+                    autoPlay
+                  />
+                ) : (
+                  <img
+                    src={activeMedia.url}
+                    alt="media"
+                    className="w-full h-full object-contain"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
     </main>
   );
 };

--- a/Playproof/src/features/team/components/azit/MainPanel.tsx
+++ b/Playproof/src/features/team/components/azit/MainPanel.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useNavigate } from "react-router-dom";
 import { Plus, Trash2, Send, Paperclip } from 'lucide-react';
 import { useAzitChat } from '@/features/team/hooks/useAzitChat';
+import { ModalShell } from "@/components/ui/ModalShell";
 
 type ChatMessage = {
   id: string;
@@ -187,53 +188,49 @@ export const MainPanel: React.FC<MainPanelProps> = ({
         </div>
       </div>
 
-      {activeMedia && (
-        <>
-          <div
-            className="fixed inset-0 z-[130] bg-black/60"
-            onClick={() => setActiveMedia(null)}
-          />
-          <div className="fixed inset-0 z-[131] flex items-center justify-center px-6">
-            <div className="w-full max-w-[960px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-4">
-              <div className="flex items-center justify-between mb-3 px-2">
-                <h3 className="text-base font-bold text-gray-900">미디어 보기</h3>
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={handleShareToHighlight}
-                    className="text-sm text-gray-500 hover:text-gray-900"
-                  >
-                    공유
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setActiveMedia(null)}
-                    className="text-sm text-gray-500 hover:text-gray-900"
-                  >
-                    닫기
-                  </button>
-                </div>
-              </div>
-              <div className="w-full aspect-video bg-black rounded-xl overflow-hidden flex items-center justify-center">
-                {activeMedia.type === "video" ? (
-                  <video
-                    src={activeMedia.url}
-                    className="w-full h-full object-contain"
-                    controls
-                    autoPlay
-                  />
-                ) : (
-                  <img
-                    src={activeMedia.url}
-                    alt="media"
-                    className="w-full h-full object-contain"
-                  />
-                )}
-              </div>
-            </div>
+      <ModalShell
+        open={Boolean(activeMedia)}
+        onOverlayClick={() => setActiveMedia(null)}
+        overlayClassName="fixed inset-0 z-[130] bg-black/60"
+        wrapperClassName="fixed inset-0 z-[131] flex items-center justify-center px-6"
+        panelClassName="w-full max-w-[960px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-4"
+      >
+        <div className="flex items-center justify-between mb-3 px-2">
+          <h3 className="text-base font-bold text-gray-900">미디어 보기</h3>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleShareToHighlight}
+              className="text-sm text-gray-500 hover:text-gray-900"
+            >
+              공유
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveMedia(null)}
+              className="text-sm text-gray-500 hover:text-gray-900"
+            >
+              닫기
+            </button>
           </div>
-        </>
-      )}
+        </div>
+        <div className="w-full aspect-video bg-black rounded-xl overflow-hidden flex items-center justify-center">
+          {activeMedia?.type === "video" ? (
+            <video
+              src={activeMedia.url}
+              className="w-full h-full object-contain"
+              controls
+              autoPlay
+            />
+          ) : activeMedia ? (
+            <img
+              src={activeMedia.url}
+              alt="media"
+              className="w-full h-full object-contain"
+            />
+          ) : null}
+        </div>
+      </ModalShell>
     </main>
   );
 };

--- a/Playproof/src/features/team/components/azit/RightPanel.tsx
+++ b/Playproof/src/features/team/components/azit/RightPanel.tsx
@@ -23,7 +23,7 @@ export const RightPanel: React.FC<RightPanelProps> = ({ clips }) => {
     shareToHighlight,
   } = useAzitMediaViewer(clips);
   return (
-    <aside className="w-[320px] bg-gray-50 border-l border-gray-200 flex flex-col h-full overflow-y-auto shrink-0 p-5 gap-6">
+    <aside className="w-full lg:w-[320px] bg-gray-50 border-t lg:border-t-0 lg:border-l border-gray-200 flex flex-col h-full overflow-y-auto shrink-0 p-5 gap-6">
       
       <ClipList
         clips={clips}

--- a/Playproof/src/features/team/components/azit/RightPanel.tsx
+++ b/Playproof/src/features/team/components/azit/RightPanel.tsx
@@ -1,5 +1,6 @@
 // src/features/team/components/azit/RightPanel.tsx
 import React from 'react';
+import { useNavigate } from "react-router-dom";
 import type { Clip } from '@/types'; // User 타입 제거
 import { ClipList } from '@/features/team/components/ClipList';
 
@@ -8,10 +9,177 @@ interface RightPanelProps {
 }
 
 export const RightPanel: React.FC<RightPanelProps> = ({ clips }) => {
+  const [isGalleryOpen, setIsGalleryOpen] = React.useState(false);
+  const [activeMedia, setActiveMedia] = React.useState<Clip | null>(null);
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const hasMedia = clips.length > 0;
+  const navigate = useNavigate();
+
+  const handleShareToHighlight = React.useCallback(async () => {
+    if (!activeMedia) return;
+    if (activeMedia.mediaType === "video") {
+      alert("영상 공유는 아직 준비 중이에요.");
+      return;
+    }
+    const sourceUrl = activeMedia.mediaUrl ?? activeMedia.thumbnailUrl;
+    if (!sourceUrl) return;
+    const response = await fetch(sourceUrl);
+    const blob = await response.blob();
+    const ext = blob.type.includes("png") ? "png" : "jpg";
+    const file = new File([blob], `highlight-share-${Date.now()}.${ext}`, {
+      type: blob.type || "image/jpeg",
+    });
+    navigate("/community?tab=하이라이트", { state: { shareFiles: [file] } });
+  }, [activeMedia, navigate]);
   return (
     <aside className="w-[320px] bg-gray-50 border-l border-gray-200 flex flex-col h-full overflow-y-auto shrink-0 p-5 gap-6">
       
-      <ClipList clips={clips} />
+      <ClipList
+        clips={clips}
+        onViewAll={() => setIsGalleryOpen(true)}
+        onSelectClip={(clip, index) => {
+          setActiveMedia(clip);
+          setActiveIndex(index);
+        }}
+      />
+
+      {isGalleryOpen && (
+        <>
+          <div className="fixed inset-0 z-[120] bg-black/30" onClick={() => setIsGalleryOpen(false)} />
+          <div className="fixed inset-0 z-[121] flex items-center justify-center px-6">
+            <div className="w-full max-w-[760px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-bold text-gray-900">최근 미디어</h3>
+                <button
+                  type="button"
+                  onClick={() => setIsGalleryOpen(false)}
+                  className="text-sm text-gray-500 hover:text-gray-900"
+                >
+                  닫기
+                </button>
+              </div>
+
+              {clips.length === 0 ? (
+                <div className="text-sm text-gray-400 py-20 text-center">
+                  보낸 미디어가 없습니다.
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4 max-h-[70vh] overflow-y-auto pr-2 custom-scrollbar">
+                  {clips.map((clip, index) => (
+                    <button
+                      key={clip.id}
+                      type="button"
+                      onClick={() => {
+                        setActiveMedia(clip);
+                        setActiveIndex(index);
+                      }}
+                      className="relative rounded-xl overflow-hidden border border-gray-200 text-left"
+                    >
+                      {clip.mediaType === "video" && clip.mediaUrl ? (
+                        <video
+                          src={clip.mediaUrl}
+                          className="w-full h-full object-cover"
+                          muted
+                          playsInline
+                        />
+                      ) : clip.thumbnailUrl ? (
+                        <img
+                          src={clip.thumbnailUrl}
+                          alt="media"
+                          className="w-full h-full object-contain bg-black/5"
+                        />
+                      ) : (
+                        <div className="w-full aspect-video bg-gray-100" />
+                      )}
+                      {clip.mediaType === "video" && (
+                        <div className="absolute bottom-2 right-2 bg-black/70 text-white text-[11px] font-semibold px-2 py-1 rounded-md">
+                          {clip.durationLabel ?? "0:00"}
+                        </div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {activeMedia && (
+        <>
+          <div
+            className="fixed inset-0 z-[130] bg-black/60"
+            onClick={() => setActiveMedia(null)}
+          />
+          <div className="fixed inset-0 z-[131] flex items-center justify-center px-6">
+            <div className="w-full max-w-[960px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-4">
+              <div className="flex items-center justify-between mb-3 px-2">
+                <h3 className="text-base font-bold text-gray-900">미디어 보기</h3>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleShareToHighlight}
+                    className="text-sm text-gray-500 hover:text-gray-900"
+                  >
+                    공유
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setActiveMedia(null)}
+                    className="text-sm text-gray-500 hover:text-gray-900"
+                  >
+                    닫기
+                  </button>
+                </div>
+              </div>
+              <div className="w-full aspect-video bg-black rounded-xl overflow-hidden relative flex items-center justify-center">
+                <button
+                  type="button"
+                  disabled={!hasMedia}
+                  onClick={() => {
+                    if (!hasMedia) return;
+                    const nextIndex = (activeIndex - 1 + clips.length) % clips.length;
+                    setActiveIndex(nextIndex);
+                    setActiveMedia(clips[nextIndex]);
+                  }}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 text-gray-700 shadow-sm flex items-center justify-center hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  ‹
+                </button>
+                {activeMedia.mediaType === "video" && activeMedia.mediaUrl ? (
+                  <video
+                    src={activeMedia.mediaUrl}
+                    className="w-full h-full object-contain"
+                    controls
+                    autoPlay
+                  />
+                ) : activeMedia.thumbnailUrl ? (
+                  <img
+                    src={activeMedia.thumbnailUrl}
+                    alt="media"
+                    className="w-full h-full object-contain"
+                  />
+                ) : (
+                  <div className="text-gray-400 text-sm">미디어가 없습니다.</div>
+                )}
+                <button
+                  type="button"
+                  disabled={!hasMedia}
+                  onClick={() => {
+                    if (!hasMedia) return;
+                    const nextIndex = (activeIndex + 1) % clips.length;
+                    setActiveIndex(nextIndex);
+                    setActiveMedia(clips[nextIndex]);
+                  }}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 text-gray-700 shadow-sm flex items-center justify-center hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  ›
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
 
     </aside>
   );

--- a/Playproof/src/features/team/components/azit/RightPanel.tsx
+++ b/Playproof/src/features/team/components/azit/RightPanel.tsx
@@ -1,185 +1,156 @@
 // src/features/team/components/azit/RightPanel.tsx
 import React from 'react';
-import { useNavigate } from "react-router-dom";
+import { useAzitMediaViewer } from "@/features/team/hooks/useAzitMediaViewer";
 import type { Clip } from '@/types'; // User 타입 제거
 import { ClipList } from '@/features/team/components/ClipList';
+import { ModalShell } from "@/components/ui/ModalShell";
 
 interface RightPanelProps {
   clips: Clip[];
 }
 
 export const RightPanel: React.FC<RightPanelProps> = ({ clips }) => {
-  const [isGalleryOpen, setIsGalleryOpen] = React.useState(false);
-  const [activeMedia, setActiveMedia] = React.useState<Clip | null>(null);
-  const [activeIndex, setActiveIndex] = React.useState(0);
-  const hasMedia = clips.length > 0;
-  const navigate = useNavigate();
-
-  const handleShareToHighlight = React.useCallback(async () => {
-    if (!activeMedia) return;
-    if (activeMedia.mediaType === "video") {
-      alert("영상 공유는 아직 준비 중이에요.");
-      return;
-    }
-    const sourceUrl = activeMedia.mediaUrl ?? activeMedia.thumbnailUrl;
-    if (!sourceUrl) return;
-    const response = await fetch(sourceUrl);
-    const blob = await response.blob();
-    const ext = blob.type.includes("png") ? "png" : "jpg";
-    const file = new File([blob], `highlight-share-${Date.now()}.${ext}`, {
-      type: blob.type || "image/jpeg",
-    });
-    navigate("/community?tab=하이라이트", { state: { shareFiles: [file] } });
-  }, [activeMedia, navigate]);
+  const {
+    isGalleryOpen,
+    activeMedia,
+    hasMedia,
+    closeGallery,
+    openMedia,
+    closeMedia,
+    goPrev,
+    goNext,
+    goHighlight,
+    shareToHighlight,
+  } = useAzitMediaViewer(clips);
   return (
     <aside className="w-[320px] bg-gray-50 border-l border-gray-200 flex flex-col h-full overflow-y-auto shrink-0 p-5 gap-6">
       
       <ClipList
         clips={clips}
-        onViewAll={() => setIsGalleryOpen(true)}
-        onSelectClip={(clip, index) => {
-          setActiveMedia(clip);
-          setActiveIndex(index);
-        }}
+        onViewAll={goHighlight}
+        onSelectClip={openMedia}
+        viewAllLabel="하이라이트 전체보기"
       />
 
-      {isGalleryOpen && (
-        <>
-          <div className="fixed inset-0 z-[120] bg-black/30" onClick={() => setIsGalleryOpen(false)} />
-          <div className="fixed inset-0 z-[121] flex items-center justify-center px-6">
-            <div className="w-full max-w-[760px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-bold text-gray-900">최근 미디어</h3>
-                <button
-                  type="button"
-                  onClick={() => setIsGalleryOpen(false)}
-                  className="text-sm text-gray-500 hover:text-gray-900"
-                >
-                  닫기
-                </button>
-              </div>
+      <ModalShell
+        open={isGalleryOpen}
+        onOverlayClick={closeGallery}
+        overlayClassName="fixed inset-0 z-[120] bg-black/30"
+        wrapperClassName="fixed inset-0 z-[121] flex items-center justify-center px-6"
+        panelClassName="w-full max-w-[760px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-6"
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-bold text-gray-900">최근 미디어</h3>
+          <button
+            type="button"
+            onClick={closeGallery}
+            className="text-sm text-gray-500 hover:text-gray-900"
+          >
+            닫기
+          </button>
+        </div>
 
-              {clips.length === 0 ? (
-                <div className="text-sm text-gray-400 py-20 text-center">
-                  보낸 미디어가 없습니다.
-                </div>
-              ) : (
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-4 max-h-[70vh] overflow-y-auto pr-2 custom-scrollbar">
-                  {clips.map((clip, index) => (
-                    <button
-                      key={clip.id}
-                      type="button"
-                      onClick={() => {
-                        setActiveMedia(clip);
-                        setActiveIndex(index);
-                      }}
-                      className="relative rounded-xl overflow-hidden border border-gray-200 text-left"
-                    >
-                      {clip.mediaType === "video" && clip.mediaUrl ? (
-                        <video
-                          src={clip.mediaUrl}
-                          className="w-full h-full object-cover"
-                          muted
-                          playsInline
-                        />
-                      ) : clip.thumbnailUrl ? (
-                        <img
-                          src={clip.thumbnailUrl}
-                          alt="media"
-                          className="w-full h-full object-contain bg-black/5"
-                        />
-                      ) : (
-                        <div className="w-full aspect-video bg-gray-100" />
-                      )}
-                      {clip.mediaType === "video" && (
-                        <div className="absolute bottom-2 right-2 bg-black/70 text-white text-[11px] font-semibold px-2 py-1 rounded-md">
-                          {clip.durationLabel ?? "0:00"}
-                        </div>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+        {clips.length === 0 ? (
+          <div className="text-sm text-gray-400 py-20 text-center">
+            보낸 미디어가 없습니다.
           </div>
-        </>
-      )}
-
-      {activeMedia && (
-        <>
-          <div
-            className="fixed inset-0 z-[130] bg-black/60"
-            onClick={() => setActiveMedia(null)}
-          />
-          <div className="fixed inset-0 z-[131] flex items-center justify-center px-6">
-            <div className="w-full max-w-[960px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-4">
-              <div className="flex items-center justify-between mb-3 px-2">
-                <h3 className="text-base font-bold text-gray-900">미디어 보기</h3>
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={handleShareToHighlight}
-                    className="text-sm text-gray-500 hover:text-gray-900"
-                  >
-                    공유
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setActiveMedia(null)}
-                    className="text-sm text-gray-500 hover:text-gray-900"
-                  >
-                    닫기
-                  </button>
-                </div>
-              </div>
-              <div className="w-full aspect-video bg-black rounded-xl overflow-hidden relative flex items-center justify-center">
-                <button
-                  type="button"
-                  disabled={!hasMedia}
-                  onClick={() => {
-                    if (!hasMedia) return;
-                    const nextIndex = (activeIndex - 1 + clips.length) % clips.length;
-                    setActiveIndex(nextIndex);
-                    setActiveMedia(clips[nextIndex]);
-                  }}
-                  className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 text-gray-700 shadow-sm flex items-center justify-center hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  ‹
-                </button>
-                {activeMedia.mediaType === "video" && activeMedia.mediaUrl ? (
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 max-h-[70vh] overflow-y-auto pr-2 custom-scrollbar">
+            {clips.map((clip, index) => (
+              <button
+                key={clip.id}
+                type="button"
+                onClick={() => openMedia(clip, index)}
+                className="relative rounded-xl overflow-hidden border border-gray-200 text-left"
+              >
+                {clip.mediaType === "video" && clip.mediaUrl ? (
                   <video
-                    src={activeMedia.mediaUrl}
-                    className="w-full h-full object-contain"
-                    controls
-                    autoPlay
+                    src={clip.mediaUrl}
+                    className="w-full h-full object-cover"
+                    muted
+                    playsInline
                   />
-                ) : activeMedia.thumbnailUrl ? (
+                ) : clip.thumbnailUrl ? (
                   <img
-                    src={activeMedia.thumbnailUrl}
+                    src={clip.thumbnailUrl}
                     alt="media"
-                    className="w-full h-full object-contain"
+                    className="w-full h-full object-contain bg-black/5"
                   />
                 ) : (
-                  <div className="text-gray-400 text-sm">미디어가 없습니다.</div>
+                  <div className="w-full aspect-video bg-gray-100" />
                 )}
-                <button
-                  type="button"
-                  disabled={!hasMedia}
-                  onClick={() => {
-                    if (!hasMedia) return;
-                    const nextIndex = (activeIndex + 1) % clips.length;
-                    setActiveIndex(nextIndex);
-                    setActiveMedia(clips[nextIndex]);
-                  }}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 text-gray-700 shadow-sm flex items-center justify-center hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  ›
-                </button>
-              </div>
-            </div>
+                {clip.mediaType === "video" && (
+                  <div className="absolute bottom-2 right-2 bg-black/70 text-white text-[11px] font-semibold px-2 py-1 rounded-md">
+                    {clip.durationLabel ?? "0:00"}
+                  </div>
+                )}
+              </button>
+            ))}
           </div>
-        </>
-      )}
+        )}
+      </ModalShell>
+
+      <ModalShell
+        open={Boolean(activeMedia)}
+        onOverlayClick={closeMedia}
+        overlayClassName="fixed inset-0 z-[130] bg-black/60"
+        wrapperClassName="fixed inset-0 z-[131] flex items-center justify-center px-6"
+        panelClassName="w-full max-w-[960px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-4"
+      >
+        <div className="flex items-center justify-between mb-3 px-2">
+          <h3 className="text-base font-bold text-gray-900">미디어 보기</h3>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={shareToHighlight}
+              className="text-sm text-gray-500 hover:text-gray-900"
+            >
+              공유
+            </button>
+            <button
+              type="button"
+              onClick={closeMedia}
+              className="text-sm text-gray-500 hover:text-gray-900"
+            >
+              닫기
+            </button>
+          </div>
+        </div>
+        <div className="w-full aspect-video bg-black rounded-xl overflow-hidden relative flex items-center justify-center">
+          <button
+            type="button"
+            disabled={!hasMedia}
+            onClick={goPrev}
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 text-gray-700 shadow-sm flex items-center justify-center hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            ‹
+          </button>
+          {activeMedia?.mediaType === "video" && activeMedia.mediaUrl ? (
+            <video
+              src={activeMedia.mediaUrl}
+              className="w-full h-full object-contain"
+              controls
+              autoPlay
+            />
+          ) : activeMedia?.thumbnailUrl ? (
+            <img
+              src={activeMedia.thumbnailUrl}
+              alt="media"
+              className="w-full h-full object-contain"
+            />
+          ) : (
+            <div className="text-gray-400 text-sm">미디어가 없습니다.</div>
+          )}
+          <button
+            type="button"
+            disabled={!hasMedia}
+            onClick={goNext}
+            className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 text-gray-700 shadow-sm flex items-center justify-center hover:bg-white disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            ›
+          </button>
+        </div>
+      </ModalShell>
 
     </aside>
   );

--- a/Playproof/src/features/team/components/azit/chat/ChatRoomCreateModal.tsx
+++ b/Playproof/src/features/team/components/azit/chat/ChatRoomCreateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { X, Search } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -20,15 +20,14 @@ export const ChatRoomCreateModal = ({ anchorEl, onClose, onCreate }: ChatRoomCre
   const [name, setName] = useState("");
   const [type, setType] = useState<"TEXT" | "VOICE">("TEXT");
   const [isPrivate, setIsPrivate] = useState(false);
-  const [position, setPosition] = useState({ top: 0, left: 0 });
 
-  useEffect(() => {
-    if (!anchorEl) return;
+  const position = useMemo(() => {
+    if (!anchorEl) return { top: 0, left: 0 };
     const rect = anchorEl.getBoundingClientRect();
-    setPosition({
+    return {
       top: rect.bottom + window.scrollY + 8,
       left: rect.left + window.scrollX,
-    });
+    };
   }, [anchorEl]);
 
   if (!anchorEl) return null;

--- a/Playproof/src/features/team/components/azit/chat/ChatRoomCreateModal.tsx
+++ b/Playproof/src/features/team/components/azit/chat/ChatRoomCreateModal.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useState } from "react";
+import { X, Search } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { cn } from "@/utils/cn";
+
+export interface ChatRoomCreateData {
+  name: string;
+  type: "TEXT" | "VOICE";
+  isPrivate: boolean;
+}
+
+interface ChatRoomCreateModalProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  onCreate: (data: ChatRoomCreateData) => void;
+}
+
+export const ChatRoomCreateModal = ({ anchorEl, onClose, onCreate }: ChatRoomCreateModalProps) => {
+  const [name, setName] = useState("");
+  const [type, setType] = useState<"TEXT" | "VOICE">("TEXT");
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+
+  useEffect(() => {
+    if (!anchorEl) return;
+    const rect = anchorEl.getBoundingClientRect();
+    setPosition({
+      top: rect.bottom + window.scrollY + 8,
+      left: rect.left + window.scrollX,
+    });
+  }, [anchorEl]);
+
+  if (!anchorEl) return null;
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    onCreate({ name, type, isPrivate });
+    onClose();
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[100] bg-transparent" onClick={onClose} />
+      <div
+        className="absolute z-[101] w-[400px] bg-white rounded-[20px] shadow-2xl border border-gray-100 overflow-hidden flex flex-col animate-in fade-in zoom-in-95 duration-200"
+        style={{ top: position.top, left: position.left }}
+      >
+        
+        {/* 1. 헤더 (돋보기 아이콘 포함) */}
+        <div className="flex items-center justify-between px-6 py-5">
+          <div className="flex items-center gap-2">
+            <Search className="w-5 h-5 text-gray-900" />
+            <h2 className="text-lg font-bold text-gray-900">채팅방 생성</h2>
+          </div>
+          <button 
+            onClick={onClose} 
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+
+        {/* 2. 본문 */}
+        <div className="px-6 flex flex-col gap-6 pb-6">
+          
+          {/* 이름 입력 */}
+          <div className="flex flex-col gap-2">
+            <label className="text-[15px] font-bold text-gray-900">
+              채팅방 이름
+            </label>
+            <Input
+              variant="light"
+              placeholder="최대 20글자"
+              maxLength={20}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="bg-white border-gray-200 focus:border-black rounded-xl"
+            />
+          </div>
+
+          {/* 유형 선택 (라디오 버튼) */}
+          <div className="flex flex-col gap-3">
+            <label className="text-[15px] font-bold text-gray-900">
+              채팅방 유형
+            </label>
+            
+            <div className="flex flex-col gap-4">
+              {/* 텍스트 채팅방 */}
+              <label className="flex items-start gap-3 cursor-pointer group">
+                <div className="relative flex items-center mt-1">
+                  <input
+                    type="radio"
+                    name="chatType"
+                    className="peer sr-only"
+                    checked={type === "TEXT"}
+                    onChange={() => setType("TEXT")}
+                  />
+                  <div className={cn(
+                    "w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all",
+                    type === "TEXT" 
+                      ? "border-[#1533B6]" 
+                      : "border-gray-300 group-hover:border-gray-400"
+                  )}>
+                    {type === "TEXT" && (
+                      <div className="w-2.5 h-2.5 rounded-full bg-[#1533B6]" />
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <div className={cn("text-[15px] font-bold", type === "TEXT" ? "text-gray-900" : "text-gray-500")}>텍스트 채팅방</div>
+                  <div className="text-[13px] text-gray-400 mt-0.5">
+                    자유롭게 대화를 나눌 수 있는 텍스트 기반 채팅방
+                  </div>
+                </div>
+              </label>
+
+              {/* 음성 채팅방 */}
+              <label className="flex items-start gap-3 cursor-pointer group">
+                <div className="relative flex items-center mt-1">
+                  <input
+                    type="radio"
+                    name="chatType"
+                    className="peer sr-only"
+                    checked={type === "VOICE"}
+                    onChange={() => setType("VOICE")}
+                  />
+                   <div className={cn(
+                    "w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all",
+                    type === "VOICE" 
+                      ? "border-[#1533B6]" 
+                      : "border-gray-300 group-hover:border-gray-400"
+                  )}>
+                    {type === "VOICE" && (
+                      <div className="w-2.5 h-2.5 rounded-full bg-[#1533B6]" />
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <div className={cn("text-[15px] font-bold", type === "VOICE" ? "text-gray-900" : "text-gray-500")}>음성 채팅방</div>
+                  <div className="text-[13px] text-gray-400 mt-0.5">
+                    실시간으로 목소리를 들으며 소통하는 음성 채팅방
+                  </div>
+                </div>
+              </label>
+            </div>
+          </div>
+
+          {/* 비공개 토글 */}
+          <div className="flex items-center justify-between mt-2">
+            <span className="text-[15px] font-bold text-gray-900">비공개 채팅방</span>
+            <button
+              onClick={() => setIsPrivate(!isPrivate)}
+              className={cn(
+                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none",
+                isPrivate ? "bg-[#1533B6]" : "bg-gray-200"
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+                  isPrivate ? "translate-x-5" : "translate-x-0"
+                )}
+              />
+            </button>
+          </div>
+        </div>
+
+        {/* 3. 하단 버튼 (검은색) */}
+        <div className="p-6 pt-0">
+          <Button
+            fullWidth
+            onClick={handleSubmit}
+            disabled={!name.trim()}
+            className={cn(
+              "h-14 rounded-xl text-base font-bold transition-colors",
+              name.trim() 
+                ? "bg-black hover:bg-gray-900 text-white" 
+                : "bg-[#C6C6C6] text-white cursor-not-allowed"
+            )}
+          >
+            업로드
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/Playproof/src/features/team/components/azit/schedule/ScheduleItem.tsx
+++ b/Playproof/src/features/team/components/azit/schedule/ScheduleItem.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useState } from 'react';
+import { Users, Volume2 } from 'lucide-react';
+import { Card } from '@/components/ui/Card';
+import type { Schedule } from '@/features/team/types/types';
+import { getScheduleActionState } from '@/features/team/utils/scheduleAction';
+
+type ScheduleItemProps = {
+  schedule: Schedule;
+  currentUserId: string;
+  onStatusChange?: (id: string, status: 'JOIN' | 'DECLINE') => void;
+};
+
+export const ScheduleItem: React.FC<ScheduleItemProps> = ({
+  schedule,
+  currentUserId,
+  onStatusChange,
+}) => {
+  const [timeLeft, setTimeLeft] = useState<string>('');
+
+  useEffect(() => {
+    const updateTimer = () => {
+      const now = new Date();
+      const diff = schedule.fullDate.getTime() - now.getTime();
+      if (diff <= 0) {
+        setTimeLeft('00 : 00 : 00');
+        return;
+      }
+      const h = Math.floor(diff / (1000 * 60 * 60));
+      const m = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+      const s = Math.floor((diff % (1000 * 60)) / 1000);
+      setTimeLeft(`${h.toString().padStart(2, '0')} : ${m
+        .toString()
+        .padStart(2, '0')} : ${s.toString().padStart(2, '0')}`);
+    };
+    updateTimer();
+    const interval = setInterval(updateTimer, 1000);
+    return () => clearInterval(interval);
+  }, [schedule]);
+
+  const formatTime = (d?: Date) =>
+    d
+      ? d.toLocaleTimeString('ko-KR', {
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        })
+      : '';
+
+  const actionState = getScheduleActionState(schedule, currentUserId);
+  const { status, joinedParticipants, joinedCount } = actionState;
+
+  const renderActionButtons = () => {
+    switch (status) {
+      case 'FEEDBACK_DONE':
+        return (
+          <button
+            disabled
+            className="w-full bg-gray-200 text-gray-500 py-3 rounded-xl text-sm font-bold cursor-not-allowed"
+          >
+            완료됨
+          </button>
+        );
+      case 'RECRUITMENT_FAILED':
+        return (
+          <button className="w-full bg-blue-600 text-white py-3 rounded-xl text-sm font-bold flex items-center justify-center gap-2 hover:bg-blue-700 transition-colors">
+            <Users className="w-4 h-4" /> 추가 게이머 찾기
+          </button>
+        );
+      case 'TIME_OVER':
+        return (
+          <button className="w-full bg-blue-100 text-blue-600 py-3 rounded-xl text-sm font-bold hover:bg-blue-200 transition-colors">
+            피드백 남기기
+          </button>
+        );
+      case 'CREATOR':
+        return (
+          <button className="w-full bg-white border border-blue-600 text-blue-600 py-3 rounded-xl text-sm font-bold cursor-default">
+            모집중
+          </button>
+        );
+      case 'JOINED':
+        return (
+          <button className="w-full bg-white border border-blue-600 text-blue-600 py-3 rounded-xl text-sm font-bold cursor-default">
+            신청 완료
+          </button>
+        );
+      case 'DECLINED':
+        return (
+          <button className="w-full bg-white border border-blue-600 text-blue-600 py-3 rounded-xl text-sm font-bold cursor-default">
+            거절함
+          </button>
+        );
+      case 'PENDING':
+      default:
+        return (
+          <div className="flex gap-2 w-full">
+            <button
+              onClick={() => onStatusChange?.(schedule.id, 'DECLINE')}
+              className="flex-1 bg-white border border-blue-600 text-blue-600 py-3 rounded-xl text-sm font-bold hover:bg-gray-50 transition-colors"
+            >
+              불참
+            </button>
+            <button
+              onClick={() => onStatusChange?.(schedule.id, 'JOIN')}
+              className="flex-1 bg-blue-600 text-white py-3 rounded-xl text-sm font-bold hover:bg-blue-700 transition-colors"
+            >
+              참여
+            </button>
+          </div>
+        );
+    }
+  };
+
+  return (
+    <Card className="overflow-hidden border border-gray-200 shadow-sm rounded-xl bg-white mb-4 last:mb-0">
+      <div className="p-4">
+        <div className="flex gap-4 mb-4">
+          <div className="flex flex-col items-center justify-center bg-gray-50 border border-gray-100 rounded-xl w-[52px] h-[52px] shrink-0">
+            <span className="text-[11px] text-gray-500 font-medium uppercase leading-none mb-0.5">
+              {schedule.fullDate.toLocaleDateString('en-US', { weekday: 'short' })}
+            </span>
+            <span className="text-xl font-bold text-gray-900 leading-none">
+              {schedule.fullDate.getDate()}
+            </span>
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-lg font-bold text-gray-900 leading-none">
+                {formatTime(schedule.fullDate)}
+              </span>
+              <Volume2 className="w-4 h-4 text-gray-400" />
+            </div>
+            <div className="text-sm text-gray-600 font-medium truncate">
+              {schedule.title}
+            </div>
+            <div className="flex -space-x-1.5 mt-2">
+              {joinedParticipants.slice(0, 4).map((p, i) => (
+                <div key={i} className="w-6 h-6 rounded-full bg-gray-200 border-2 border-white overflow-hidden">
+                  {p.user?.avatarUrl ? (
+                    <img src={p.user.avatarUrl} alt="" className="w-full h-full object-cover" />
+                  ) : (
+                    <div className="w-full h-full bg-gray-200" />
+                  )}
+                </div>
+              ))}
+              <div className="w-6 h-6 rounded-full bg-white border-2 border-white flex items-center justify-center ml-1">
+                <span className="text-xs font-bold text-green-500">
+                  {joinedCount}/{schedule.maxMembers}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-gray-50 rounded-xl py-3 text-center mb-3">
+          <div className="text-[11px] text-gray-500 mb-0.5">매칭완료까지</div>
+          <div className="text-2xl font-black text-gray-900 tabular-nums tracking-tight">
+            {timeLeft || '00 : 00 : 00'}
+          </div>
+        </div>
+
+        {renderActionButtons()}
+      </div>
+    </Card>
+  );
+};

--- a/Playproof/src/features/team/components/azit/schedule/ScheduleItem.tsx
+++ b/Playproof/src/features/team/components/azit/schedule/ScheduleItem.tsx
@@ -8,12 +8,14 @@ type ScheduleItemProps = {
   schedule: Schedule;
   currentUserId: string;
   onStatusChange?: (id: string, status: 'JOIN' | 'DECLINE') => void;
+  onFeedback?: (scheduleId: string) => void;
 };
 
 export const ScheduleItem: React.FC<ScheduleItemProps> = ({
   schedule,
   currentUserId,
   onStatusChange,
+  onFeedback,
 }) => {
   const [timeLeft, setTimeLeft] = useState<string>('');
 
@@ -68,7 +70,10 @@ export const ScheduleItem: React.FC<ScheduleItemProps> = ({
         );
       case 'TIME_OVER':
         return (
-          <button className="w-full bg-blue-100 text-blue-600 py-3 rounded-xl text-sm font-bold hover:bg-blue-200 transition-colors">
+          <button
+            onClick={() => onFeedback?.(schedule.id)}
+            className="w-full bg-blue-100 text-blue-600 py-3 rounded-xl text-sm font-bold hover:bg-blue-200 transition-colors"
+          >
             피드백 남기기
           </button>
         );

--- a/Playproof/src/features/team/components/feedback/FeedbackModal.tsx
+++ b/Playproof/src/features/team/components/feedback/FeedbackModal.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { X } from "lucide-react";
+import { ModalShell } from "@/components/ui/ModalShell";
+
+type FeedbackModalProps = {
+  open: boolean;
+  targetName: string;
+  targetMeta?: string;
+  avatarUrl?: string;
+  required?: boolean;
+  onClose?: () => void;
+  onSubmit: (payload: {
+    positive: string[];
+    negative: string[];
+    memo: string;
+    blockUser: boolean;
+  }) => void;
+};
+
+const POSITIVE_TAGS = ["협력적이었어요", "소통이 원활했어요", "재밌어요", "실력이 우수해요", "하드캐리 가능", "오더 가능!"];
+const NEGATIVE_TAGS = ["과도한 욕설", "고의 트롤,어뷰징", "계정 도용 행위", "핵,치트 의심"];
+
+export const FeedbackModal: React.FC<FeedbackModalProps> = ({
+  open,
+  targetName,
+  targetMeta,
+  avatarUrl,
+  required = false,
+  onClose,
+  onSubmit,
+}) => {
+  const [positive, setPositive] = React.useState<string[]>([]);
+  const [negative, setNegative] = React.useState<string[]>([]);
+  const [memo, setMemo] = React.useState("");
+  const [blockUser, setBlockUser] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setPositive([]);
+    setNegative([]);
+    setMemo("");
+    setBlockUser(false);
+  }, [open]);
+
+  if (!open) return null;
+
+  const toggleTag = (
+    target: string,
+    list: string[],
+    setList: React.Dispatch<React.SetStateAction<string[]>>,
+    limit: number
+  ) => {
+    setList((prev) => {
+      if (prev.includes(target)) return prev.filter((tag) => tag !== target);
+      if (prev.length >= limit) return prev;
+      return [...prev, target];
+    });
+  };
+
+  return (
+    <ModalShell
+      open={open}
+      onOverlayClick={!required ? onClose : undefined}
+      overlayClassName="fixed inset-0 z-[140] bg-black/40"
+      wrapperClassName="fixed inset-0 z-[141] flex items-center justify-center px-6"
+      panelClassName="w-full max-w-[620px] bg-white rounded-2xl shadow-2xl border border-gray-100 p-6"
+    >
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-extrabold text-gray-900">피드백 작성</h2>
+            {!required && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-gray-400 hover:text-gray-700"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            )}
+          </div>
+
+        <div className="mt-6 flex items-center gap-4">
+            <div className="w-16 h-16 rounded-full bg-gray-200 overflow-hidden">
+              {avatarUrl ? (
+                <img src={avatarUrl} alt="" className="w-full h-full object-cover" />
+              ) : null}
+            </div>
+            <div>
+              <div className="text-lg font-bold text-gray-900">{targetName}</div>
+              <div className="text-xs text-gray-500">{targetMeta ?? "Tier TS 90"}</div>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <div className="text-sm font-bold text-gray-900 mb-2">긍정 피드백 (3개 이하)</div>
+            <div className="grid grid-cols-2 gap-3">
+              {POSITIVE_TAGS.map((tag) => (
+                <label key={tag} className="flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={positive.includes(tag)}
+                    onChange={() => toggleTag(tag, positive, setPositive, 3)}
+                    className="h-4 w-4"
+                  />
+                  {tag}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <div className="text-sm font-bold text-gray-900 mb-2">부정 피드백 (3개 이하)</div>
+            <div className="grid grid-cols-2 gap-3">
+              {NEGATIVE_TAGS.map((tag) => (
+                <label key={tag} className="flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={negative.includes(tag)}
+                    onChange={() => toggleTag(tag, negative, setNegative, 3)}
+                    className="h-4 w-4"
+                  />
+                  {tag}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <textarea
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              placeholder="좋았던 점 혹은 개선할 점을 작성해주세요. (선택)"
+              rows={4}
+              className="w-full rounded-xl border border-gray-200 p-3 text-sm text-gray-700 focus:outline-none focus:border-gray-400"
+            />
+          </div>
+
+          <div className="mt-4 flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={blockUser}
+              onChange={() => setBlockUser((prev) => !prev)}
+              className="h-4 w-4"
+            />
+            이 유저 다시 만나지 않기
+          </div>
+
+          <button
+            type="button"
+            className="mt-6 w-full h-12 rounded-xl bg-gray-900 text-white font-semibold hover:bg-black transition-colors"
+            onClick={() => onSubmit({ positive, negative, memo, blockUser })}
+          >
+            피드백 제출하기
+          </button>
+    </ModalShell>
+  );
+};

--- a/Playproof/src/features/team/components/schedule/ScheduleCreateModal.tsx
+++ b/Playproof/src/features/team/components/schedule/ScheduleCreateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { X, Calendar as CalendarIcon, Clock, AlertCircle } from "lucide-react"; // AlertCircle 추가
 import { DayPicker, type DateRange } from "react-day-picker";
 import "react-day-picker/style.css"; 
@@ -6,6 +6,7 @@ import "react-day-picker/style.css";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { cn } from "@/utils/cn";
+import { useScheduleCreateState } from "@/features/team/hooks/useScheduleCreateState";
 
 // ---[ 시간 선택기 (변경 없음) ]---
 interface TimeSelection {
@@ -63,69 +64,25 @@ interface ScheduleCreateModalProps {
 }
 
 export const ScheduleCreateModal = ({ anchorEl, onClose, onCreate }: ScheduleCreateModalProps) => {
-  const [position, setPosition] = useState({ top: 0, left: 0 });
-
-  const [title, setTitle] = useState("");
-  const [recruitCount, setRecruitCount] = useState(0); // 0명이어도 생성 가능 (필요 시 1로 수정)
-  const [gameDate, setGameDate] = useState<Date | undefined>(undefined);
-  const [isGameDateOpen, setIsGameDateOpen] = useState(false);
-  const [gameStartTime, setGameStartTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
-  const [gameEndTime, setGameEndTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
-  const [recruitRange, setRecruitRange] = useState<DateRange | undefined>(undefined);
-  const [isRecruitDateOpen, setIsRecruitDateOpen] = useState(false);
-  const [recruitStartTime, setRecruitStartTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
-  const [recruitEndTime, setRecruitEndTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
-  const [activeTimePicker, setActiveTimePicker] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (anchorEl) {
-      const rect = anchorEl.getBoundingClientRect();
-      setPosition({
-        top: rect.bottom + window.scrollY + 8, 
-        left: rect.left + window.scrollX
-      });
-    }
-  }, [anchorEl]);
+  const { state, actions } = useScheduleCreateState({ anchorEl, onCreate, onClose });
 
   if (!anchorEl) return null;
-
-  const handleRecruitCount = (delta: number) => setRecruitCount((prev) => Math.max(0, prev + delta));
-  const formatDate = (date: Date | undefined) => date ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}` : "날짜를 선택해주세요.";
-  const formatRange = (range: DateRange | undefined) => range?.from ? `${formatDate(range.from)} ~ ${range.to ? formatDate(range.to) : formatDate(range.from)}` : "날짜를 선택해주세요.";
-
-  // ✅ [핵심 수정] 유효성 검사 로직 개선
-  const validateForm = () => {
-    if (!title.trim()) return { isValid: false, msg: "제목을 입력해주세요." };
-    if (!gameDate) return { isValid: false, msg: "게임 일정을 선택해주세요." };
-    if (!recruitRange?.from) return { isValid: false, msg: "모집 기간을 선택해주세요." };
-    
-    // 날짜 비교 시 '시간'을 00:00:00으로 초기화하여 순수 날짜만 비교
-    const game = new Date(gameDate);
-    game.setHours(0, 0, 0, 0);
-
-    const recruitStart = new Date(recruitRange.from);
-    recruitStart.setHours(0, 0, 0, 0);
-
-    // 모집 시작일이 게임일보다 늦으면 안 됨
-    if (recruitStart > game) return { isValid: false, msg: "모집 기간이 게임 일정보다 늦습니다." };
-
-    if (recruitRange.to) {
-      const recruitEnd = new Date(recruitRange.to);
-      recruitEnd.setHours(0, 0, 0, 0);
-      // 모집 종료일이 게임일보다 늦으면 안 됨
-      if (recruitEnd > game) return { isValid: false, msg: "모집 종료일은 게임 일정 이전이어야 합니다." };
-    }
-
-    return { isValid: true, msg: "" };
-  };
-
-  const { isValid, msg } = validateForm();
-
-  const handleSubmit = () => {
-    if (!isValid) return;
-    onCreate({ title, recruitCount, gameDate, gameStartTime, gameEndTime, recruitRange, recruitStartTime, recruitEndTime });
-    onClose();
-  };
+  const {
+    position,
+    title,
+    recruitCount,
+    gameDate,
+    isGameDateOpen,
+    gameStartTime,
+    gameEndTime,
+    recruitRange,
+    isRecruitDateOpen,
+    recruitStartTime,
+    recruitEndTime,
+    activeTimePicker,
+    isValid,
+    msg,
+  } = state;
 
   return (
     <>
@@ -151,16 +108,32 @@ export const ScheduleCreateModal = ({ anchorEl, onClose, onCreate }: ScheduleCre
           {/* 1. 제목 */}
           <div className="flex flex-col gap-2">
             <label className="text-sm font-bold text-gray-900">제목</label>
-            <Input variant="light" placeholder="최대 20글자" maxLength={20} value={title} onChange={(e) => setTitle(e.target.value)} />
+            <Input
+              variant="light"
+              placeholder="최대 20글자"
+              maxLength={20}
+              value={title}
+              onChange={(e) => actions.setTitle(e.target.value)}
+            />
           </div>
 
           {/* 2. 모집 인원 */}
           <div className="flex flex-col gap-2">
             <label className="text-sm font-bold text-gray-900">모집 인원</label>
             <div className="flex items-center justify-between border border-gray-300 rounded-lg px-4 h-12">
-              <button onClick={() => handleRecruitCount(-1)} className="text-gray-400 hover:text-black text-xl font-medium px-2">-</button>
+              <button
+                onClick={() => actions.handleRecruitCount(-1)}
+                className="text-gray-400 hover:text-black text-xl font-medium px-2"
+              >
+                -
+              </button>
               <span className="font-bold text-lg">{recruitCount}</span>
-              <button onClick={() => handleRecruitCount(1)} className="text-gray-400 hover:text-black text-xl font-medium px-2">+</button>
+              <button
+                onClick={() => actions.handleRecruitCount(1)}
+                className="text-gray-400 hover:text-black text-xl font-medium px-2"
+              >
+                +
+              </button>
             </div>
           </div>
 
@@ -169,19 +142,19 @@ export const ScheduleCreateModal = ({ anchorEl, onClose, onCreate }: ScheduleCre
             <label className="text-sm font-bold text-gray-900">게임 일정</label>
             <div className="grid grid-cols-1 gap-2">
               <div className="relative">
-                <button onClick={() => setIsGameDateOpen(!isGameDateOpen)} className="w-full h-12 px-4 rounded-lg border border-gray-300 bg-white flex items-center justify-between text-sm text-gray-900 hover:border-gray-400">
-                  <span className="flex items-center gap-2"><CalendarIcon className="w-4 h-4 text-gray-400" />{formatDate(gameDate)}</span>
+                <button onClick={() => actions.setIsGameDateOpen(!isGameDateOpen)} className="w-full h-12 px-4 rounded-lg border border-gray-300 bg-white flex items-center justify-between text-sm text-gray-900 hover:border-gray-400">
+                  <span className="flex items-center gap-2"><CalendarIcon className="w-4 h-4 text-gray-400" />{actions.formatDate(gameDate)}</span>
                   <span className="text-[10px] text-gray-400">▼</span>
                 </button>
                 {isGameDateOpen && (
                   <div className="absolute top-full left-0 mt-2 bg-white border rounded-xl shadow-xl z-50 p-2">
-                    <DayPicker mode="single" selected={gameDate} onSelect={(date) => { setGameDate(date); setIsGameDateOpen(false); }} styles={{ head_cell: { width: "40px" }, cell: { width: "40px" } }} />
+                    <DayPicker mode="single" selected={gameDate} onSelect={(date) => { actions.setGameDate(date); actions.setIsGameDateOpen(false); }} styles={{ head_cell: { width: "40px" }, cell: { width: "40px" } }} />
                   </div>
                 )}
               </div>
               <div className="flex gap-2">
-                <TimePicker value={gameStartTime} onChange={setGameStartTime} isOpen={activeTimePicker === 'gameStart'} onToggle={() => setActiveTimePicker(activeTimePicker === 'gameStart' ? null : 'gameStart')} />
-                <TimePicker value={gameEndTime} onChange={setGameEndTime} isOpen={activeTimePicker === 'gameEnd'} onToggle={() => setActiveTimePicker(activeTimePicker === 'gameEnd' ? null : 'gameEnd')} />
+                <TimePicker value={gameStartTime} onChange={actions.setGameStartTime} isOpen={activeTimePicker === 'gameStart'} onToggle={() => actions.setActiveTimePicker(activeTimePicker === 'gameStart' ? null : 'gameStart')} />
+                <TimePicker value={gameEndTime} onChange={actions.setGameEndTime} isOpen={activeTimePicker === 'gameEnd'} onToggle={() => actions.setActiveTimePicker(activeTimePicker === 'gameEnd' ? null : 'gameEnd')} />
               </div>
             </div>
           </div>
@@ -191,20 +164,20 @@ export const ScheduleCreateModal = ({ anchorEl, onClose, onCreate }: ScheduleCre
             <label className="text-sm font-bold text-gray-900">인원 모집 기간</label>
             <div className="grid grid-cols-1 gap-2">
                <div className="relative">
-                <button onClick={() => setIsRecruitDateOpen(!isRecruitDateOpen)} className="w-full h-12 px-4 rounded-lg border border-gray-300 bg-white flex items-center justify-between text-sm text-gray-900 hover:border-gray-400">
-                  <span className="flex items-center gap-2"><CalendarIcon className="w-4 h-4 text-gray-400" />{formatRange(recruitRange)}</span>
+                <button onClick={() => actions.setIsRecruitDateOpen(!isRecruitDateOpen)} className="w-full h-12 px-4 rounded-lg border border-gray-300 bg-white flex items-center justify-between text-sm text-gray-900 hover:border-gray-400">
+                  <span className="flex items-center gap-2"><CalendarIcon className="w-4 h-4 text-gray-400" />{actions.formatRange(recruitRange)}</span>
                   <span className="text-[10px] text-gray-400">▼</span>
                 </button>
                 {isRecruitDateOpen && (
                   <div className="absolute top-full left-0 mt-2 bg-white border rounded-xl shadow-xl z-50 p-2">
-                    <DayPicker mode="range" selected={recruitRange} onSelect={setRecruitRange} numberOfMonths={1} styles={{ head_cell: { width: "40px" }, cell: { width: "40px" } }} />
-                    <div className="flex justify-end p-2 border-t mt-2"><button onClick={() => setIsRecruitDateOpen(false)} className="text-blue-600 text-sm font-bold">적용</button></div>
+                    <DayPicker mode="range" selected={recruitRange} onSelect={actions.setRecruitRange} numberOfMonths={1} styles={{ head_cell: { width: "40px" }, cell: { width: "40px" } }} />
+                    <div className="flex justify-end p-2 border-t mt-2"><button onClick={() => actions.setIsRecruitDateOpen(false)} className="text-blue-600 text-sm font-bold">적용</button></div>
                   </div>
                 )}
               </div>
               <div className="flex gap-2">
-                <TimePicker value={recruitStartTime} onChange={setRecruitStartTime} isOpen={activeTimePicker === 'recruitStart'} onToggle={() => setActiveTimePicker(activeTimePicker === 'recruitStart' ? null : 'recruitStart')} />
-                <TimePicker value={recruitEndTime} onChange={setRecruitEndTime} isOpen={activeTimePicker === 'recruitEnd'} onToggle={() => setActiveTimePicker(activeTimePicker === 'recruitEnd' ? null : 'recruitEnd')} />
+                <TimePicker value={recruitStartTime} onChange={actions.setRecruitStartTime} isOpen={activeTimePicker === 'recruitStart'} onToggle={() => actions.setActiveTimePicker(activeTimePicker === 'recruitStart' ? null : 'recruitStart')} />
+                <TimePicker value={recruitEndTime} onChange={actions.setRecruitEndTime} isOpen={activeTimePicker === 'recruitEnd'} onToggle={() => actions.setActiveTimePicker(activeTimePicker === 'recruitEnd' ? null : 'recruitEnd')} />
               </div>
             </div>
           </div>
@@ -219,7 +192,7 @@ export const ScheduleCreateModal = ({ anchorEl, onClose, onCreate }: ScheduleCre
               <span>{msg}</span>
             </div>
           )}
-          <Button fullWidth variant={isValid ? "primary" : "secondary"} disabled={!isValid} onClick={handleSubmit} className="h-12 text-base rounded-xl">업로드</Button>
+          <Button fullWidth variant={isValid ? "primary" : "secondary"} disabled={!isValid} onClick={actions.handleSubmit} className="h-12 text-base rounded-xl">업로드</Button>
         </div>
       </div>
     </>

--- a/Playproof/src/features/team/components/schedule/ScheduleCreateModal.tsx
+++ b/Playproof/src/features/team/components/schedule/ScheduleCreateModal.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect, useRef } from "react";
+import { X, Calendar as CalendarIcon, Clock, AlertCircle } from "lucide-react"; // AlertCircle 추가
+import { DayPicker, type DateRange } from "react-day-picker";
+import "react-day-picker/style.css"; 
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { cn } from "@/utils/cn";
+
+// ---[ 시간 선택기 (변경 없음) ]---
+interface TimeSelection {
+  ampm: "AM" | "PM";
+  hour: number;
+  minute: number;
+}
+interface TimePickerProps {
+  value: TimeSelection;
+  onChange: (value: TimeSelection) => void;
+  isOpen: boolean;
+  onToggle: () => void;
+  label?: string;
+}
+const TimePicker = ({ value, onChange, isOpen, onToggle, label }: TimePickerProps) => {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        if (isOpen) onToggle();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, onToggle]);
+  const hours = Array.from({ length: 12 }, (_, i) => i + 1);
+  const minutes = Array.from({ length: 12 }, (_, i) => i * 5);
+  const formatTimeView = () => `${value.ampm === "AM" ? "오전" : "오후"} ${value.hour}:${value.minute.toString().padStart(2, "0")}`;
+  return (
+    <div className="relative w-full" ref={dropdownRef}>
+      <button type="button" onClick={onToggle} className={cn("w-full h-12 px-4 rounded-lg border text-sm flex items-center justify-between bg-white transition-colors", isOpen ? "border-black ring-1 ring-black/10" : "border-gray-300 hover:border-gray-400", "text-gray-900")}>
+        <span className="flex items-center gap-2">
+          <Clock className="w-4 h-4 text-gray-400" />
+          {label || formatTimeView()}
+        </span>
+        <span className="text-[10px] text-gray-400">▼</span>
+      </button>
+      {isOpen && (
+        <div className="absolute top-full mt-1 left-0 w-full bg-white border border-gray-200 rounded-lg shadow-lg z-50 flex h-48 overflow-hidden text-sm">
+          <div className="flex-1 overflow-y-auto border-r border-gray-100 scrollbar-hide">{["AM", "PM"].map((type) => (<div key={type} onClick={() => onChange({ ...value, ampm: type as "AM" | "PM" })} className={cn("py-2 px-3 cursor-pointer text-center hover:bg-gray-50", value.ampm === type && "bg-blue-50 text-blue-600 font-semibold")}>{type === "AM" ? "오전" : "오후"}</div>))}</div>
+          <div className="flex-1 overflow-y-auto border-r border-gray-100 scrollbar-hide">{hours.map((h) => (<div key={h} onClick={() => onChange({ ...value, hour: h })} className={cn("py-2 px-3 cursor-pointer text-center hover:bg-gray-50", value.hour === h && "bg-blue-50 text-blue-600 font-semibold")}>{h}</div>))}</div>
+          <div className="flex-1 overflow-y-auto scrollbar-hide">{minutes.map((m) => (<div key={m} onClick={() => onChange({ ...value, minute: m })} className={cn("py-2 px-3 cursor-pointer text-center hover:bg-gray-50", value.minute === m && "bg-blue-50 text-blue-600 font-semibold")}>{m.toString().padStart(2, "0")}</div>))}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---[ 메인 컴포넌트 ]---
+
+interface ScheduleCreateModalProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  onCreate: (data: any) => void;
+}
+
+export const ScheduleCreateModal = ({ anchorEl, onClose, onCreate }: ScheduleCreateModalProps) => {
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+
+  const [title, setTitle] = useState("");
+  const [recruitCount, setRecruitCount] = useState(0); // 0명이어도 생성 가능 (필요 시 1로 수정)
+  const [gameDate, setGameDate] = useState<Date | undefined>(undefined);
+  const [isGameDateOpen, setIsGameDateOpen] = useState(false);
+  const [gameStartTime, setGameStartTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
+  const [gameEndTime, setGameEndTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
+  const [recruitRange, setRecruitRange] = useState<DateRange | undefined>(undefined);
+  const [isRecruitDateOpen, setIsRecruitDateOpen] = useState(false);
+  const [recruitStartTime, setRecruitStartTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
+  const [recruitEndTime, setRecruitEndTime] = useState<TimeSelection>({ ampm: "AM", hour: 12, minute: 0 });
+  const [activeTimePicker, setActiveTimePicker] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (anchorEl) {
+      const rect = anchorEl.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + window.scrollY + 8, 
+        left: rect.left + window.scrollX
+      });
+    }
+  }, [anchorEl]);
+
+  if (!anchorEl) return null;
+
+  const handleRecruitCount = (delta: number) => setRecruitCount((prev) => Math.max(0, prev + delta));
+  const formatDate = (date: Date | undefined) => date ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}` : "날짜를 선택해주세요.";
+  const formatRange = (range: DateRange | undefined) => range?.from ? `${formatDate(range.from)} ~ ${range.to ? formatDate(range.to) : formatDate(range.from)}` : "날짜를 선택해주세요.";
+
+  // ✅ [핵심 수정] 유효성 검사 로직 개선
+  const validateForm = () => {
+    if (!title.trim()) return { isValid: false, msg: "제목을 입력해주세요." };
+    if (!gameDate) return { isValid: false, msg: "게임 일정을 선택해주세요." };
+    if (!recruitRange?.from) return { isValid: false, msg: "모집 기간을 선택해주세요." };
+    
+    // 날짜 비교 시 '시간'을 00:00:00으로 초기화하여 순수 날짜만 비교
+    const game = new Date(gameDate);
+    game.setHours(0, 0, 0, 0);
+
+    const recruitStart = new Date(recruitRange.from);
+    recruitStart.setHours(0, 0, 0, 0);
+
+    // 모집 시작일이 게임일보다 늦으면 안 됨
+    if (recruitStart > game) return { isValid: false, msg: "모집 기간이 게임 일정보다 늦습니다." };
+
+    if (recruitRange.to) {
+      const recruitEnd = new Date(recruitRange.to);
+      recruitEnd.setHours(0, 0, 0, 0);
+      // 모집 종료일이 게임일보다 늦으면 안 됨
+      if (recruitEnd > game) return { isValid: false, msg: "모집 종료일은 게임 일정 이전이어야 합니다." };
+    }
+
+    return { isValid: true, msg: "" };
+  };
+
+  const { isValid, msg } = validateForm();
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    onCreate({ title, recruitCount, gameDate, gameStartTime, gameEndTime, recruitRange, recruitStartTime, recruitEndTime });
+    onClose();
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[100] bg-transparent" onClick={onClose} />
+      
+      <div 
+        className="absolute z-[101] bg-white rounded-2xl w-[520px] shadow-2xl border border-gray-200 overflow-hidden flex flex-col max-h-[85vh]"
+        style={{ top: position.top, left: position.left }}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <div className="flex items-center gap-2">
+            <span className="bg-gray-100 p-1.5 rounded-lg">
+               <CalendarIcon className="w-5 h-5 text-gray-600" />
+            </span>
+            <h2 className="text-lg font-bold text-gray-900">스케줄 생성</h2>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto flex flex-col gap-6 scrollbar-hide">
+          {/* 1. 제목 */}
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-bold text-gray-900">제목</label>
+            <Input variant="light" placeholder="최대 20글자" maxLength={20} value={title} onChange={(e) => setTitle(e.target.value)} />
+          </div>
+
+          {/* 2. 모집 인원 */}
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-bold text-gray-900">모집 인원</label>
+            <div className="flex items-center justify-between border border-gray-300 rounded-lg px-4 h-12">
+              <button onClick={() => handleRecruitCount(-1)} className="text-gray-400 hover:text-black text-xl font-medium px-2">-</button>
+              <span className="font-bold text-lg">{recruitCount}</span>
+              <button onClick={() => handleRecruitCount(1)} className="text-gray-400 hover:text-black text-xl font-medium px-2">+</button>
+            </div>
+          </div>
+
+          {/* 3. 게임 일정 */}
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-bold text-gray-900">게임 일정</label>
+            <div className="grid grid-cols-1 gap-2">
+              <div className="relative">
+                <button onClick={() => setIsGameDateOpen(!isGameDateOpen)} className="w-full h-12 px-4 rounded-lg border border-gray-300 bg-white flex items-center justify-between text-sm text-gray-900 hover:border-gray-400">
+                  <span className="flex items-center gap-2"><CalendarIcon className="w-4 h-4 text-gray-400" />{formatDate(gameDate)}</span>
+                  <span className="text-[10px] text-gray-400">▼</span>
+                </button>
+                {isGameDateOpen && (
+                  <div className="absolute top-full left-0 mt-2 bg-white border rounded-xl shadow-xl z-50 p-2">
+                    <DayPicker mode="single" selected={gameDate} onSelect={(date) => { setGameDate(date); setIsGameDateOpen(false); }} styles={{ head_cell: { width: "40px" }, cell: { width: "40px" } }} />
+                  </div>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <TimePicker value={gameStartTime} onChange={setGameStartTime} isOpen={activeTimePicker === 'gameStart'} onToggle={() => setActiveTimePicker(activeTimePicker === 'gameStart' ? null : 'gameStart')} />
+                <TimePicker value={gameEndTime} onChange={setGameEndTime} isOpen={activeTimePicker === 'gameEnd'} onToggle={() => setActiveTimePicker(activeTimePicker === 'gameEnd' ? null : 'gameEnd')} />
+              </div>
+            </div>
+          </div>
+
+          {/* 4. 인원 모집 기간 */}
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-bold text-gray-900">인원 모집 기간</label>
+            <div className="grid grid-cols-1 gap-2">
+               <div className="relative">
+                <button onClick={() => setIsRecruitDateOpen(!isRecruitDateOpen)} className="w-full h-12 px-4 rounded-lg border border-gray-300 bg-white flex items-center justify-between text-sm text-gray-900 hover:border-gray-400">
+                  <span className="flex items-center gap-2"><CalendarIcon className="w-4 h-4 text-gray-400" />{formatRange(recruitRange)}</span>
+                  <span className="text-[10px] text-gray-400">▼</span>
+                </button>
+                {isRecruitDateOpen && (
+                  <div className="absolute top-full left-0 mt-2 bg-white border rounded-xl shadow-xl z-50 p-2">
+                    <DayPicker mode="range" selected={recruitRange} onSelect={setRecruitRange} numberOfMonths={1} styles={{ head_cell: { width: "40px" }, cell: { width: "40px" } }} />
+                    <div className="flex justify-end p-2 border-t mt-2"><button onClick={() => setIsRecruitDateOpen(false)} className="text-blue-600 text-sm font-bold">적용</button></div>
+                  </div>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <TimePicker value={recruitStartTime} onChange={setRecruitStartTime} isOpen={activeTimePicker === 'recruitStart'} onToggle={() => setActiveTimePicker(activeTimePicker === 'recruitStart' ? null : 'recruitStart')} />
+                <TimePicker value={recruitEndTime} onChange={setRecruitEndTime} isOpen={activeTimePicker === 'recruitEnd'} onToggle={() => setActiveTimePicker(activeTimePicker === 'recruitEnd' ? null : 'recruitEnd')} />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-gray-100 bg-white flex flex-col gap-2">
+          {/* ✅ 에러 메시지 표시 (디버깅용) */}
+          {!isValid && msg && (
+            <div className="flex items-center gap-2 text-red-500 text-xs px-1">
+              <AlertCircle className="w-3 h-3" />
+              <span>{msg}</span>
+            </div>
+          )}
+          <Button fullWidth variant={isValid ? "primary" : "secondary"} disabled={!isValid} onClick={handleSubmit} className="h-12 text-base rounded-xl">업로드</Button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/Playproof/src/features/team/components/schedule/ScheduleCreateModal.tsx
+++ b/Playproof/src/features/team/components/schedule/ScheduleCreateModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { X, Calendar as CalendarIcon, Clock, AlertCircle } from "lucide-react"; // AlertCircle 추가
-import { DayPicker, type DateRange } from "react-day-picker";
+import { DayPicker } from "react-day-picker";
 import "react-day-picker/style.css"; 
 
 import { Button } from "@/components/ui/Button";
@@ -57,10 +57,12 @@ const TimePicker = ({ value, onChange, isOpen, onToggle, label }: TimePickerProp
 
 // ---[ 메인 컴포넌트 ]---
 
+import type { ScheduleCreatePayload } from "@/features/team/hooks/useScheduleCreateState";
+
 interface ScheduleCreateModalProps {
   anchorEl: HTMLElement | null;
   onClose: () => void;
-  onCreate: (data: any) => void;
+  onCreate: (data: ScheduleCreatePayload) => void;
 }
 
 export const ScheduleCreateModal = ({ anchorEl, onClose, onCreate }: ScheduleCreateModalProps) => {

--- a/Playproof/src/features/team/data/mockTeamData.ts
+++ b/Playproof/src/features/team/data/mockTeamData.ts
@@ -1,5 +1,6 @@
 // src/features/team/data/mockTeamData.ts
-import type { Azit, User, Schedule, Channel, Clip } from '../types/types';
+import type { Azit, User, Schedule, Channel } from '../types/types';
+import type { Clip } from '@/types';
 
 // 내 아지트 목록
 export const MOCK_MY_AZITS: Azit[] = [

--- a/Playproof/src/features/team/data/mockTeamData.ts
+++ b/Playproof/src/features/team/data/mockTeamData.ts
@@ -1,26 +1,11 @@
 // src/features/team/data/mockTeamData.ts
-import type { Azit, User, Schedule, Channel, Clip } from '../types';
+import type { Azit, User, Schedule, Channel, Clip } from '../types/types';
 
-// 내 아지트 목록 (네비게이션용)
+// 내 아지트 목록
 export const MOCK_MY_AZITS: Azit[] = [
-  { 
-    id: 1, 
-    name: 'Playproof', 
-    memberCount: 4, 
-    icon: '' // 아이콘이 없으면 기본 UI 표시
-  },
-  { 
-    id: 2, 
-    name: 'LoL Party', 
-    memberCount: 12, 
-    icon: 'https://via.placeholder.com/48/2563eb/FFFFFF?text=L' 
-  },
-  { 
-    id: 3, 
-    name: 'Dev Study', 
-    memberCount: 8, 
-    icon: 'https://via.placeholder.com/48/16a34a/FFFFFF?text=D' 
-  },
+  { id: 1, name: 'Playproof', memberCount: 4, icon: '' },
+  { id: 2, name: 'LoL Party', memberCount: 12, icon: 'https://via.placeholder.com/48/2563eb/FFFFFF?text=L' },
+  { id: 3, name: 'Dev Study', memberCount: 8, icon: 'https://via.placeholder.com/48/16a34a/FFFFFF?text=D' },
 ];
 
 // 멤버 목록
@@ -32,186 +17,137 @@ export const mockMembers: User[] = [
   { id: 5, nickname: '모모', statusMessage: '데바데 할 사람?', isOnline: true },
 ];
 
+// 아지트별 멤버 매핑
 export const mockMembersByAzit: Record<number, User[]> = {
-  1: [
-    { id: 1, nickname: '레나', statusMessage: '즐겜 유저', isOnline: true },
-    { id: 2, nickname: '엘릭', statusMessage: 'FE 개발 중...', isOnline: true },
-    { id: 3, nickname: '카이', statusMessage: '밥 먹으러 감', isOnline: false },
-  ],
-  2: [
-    { id: 6, nickname: '로이', statusMessage: 'LoL 랭크 올림', isOnline: true },
-    { id: 7, nickname: '노아', statusMessage: '정글 연습 중', isOnline: true },
-    { id: 8, nickname: '베카', statusMessage: '서폿 유저', isOnline: false },
-  ],
-  3: [
-    { id: 9, nickname: '수지', statusMessage: '스터디 집중', isOnline: true },
-    { id: 10, nickname: '도윤', statusMessage: 'CS 기록 중', isOnline: false },
-    { id: 11, nickname: '하린', statusMessage: '자료 공유 가능', isOnline: true },
-  ],
+  1: mockMembers.slice(0, 3),
+  2: mockMembers.slice(0, 5),
+  3: mockMembers.slice(2, 5),
 };
 
-// 스케줄 목록
+// [중요] 모든 케이스 테스트를 위한 스케줄 데이터
+// 현재 로그인한 유저 ID는 '1'(레나)로 가정합니다.
 export const mockSchedules: Schedule[] = [
+  // Case 1: [방장] 모집중 (내가 방장이고, 시간이 남음)
   {
-    id: 1,
-    title: '데바데 4인큐',
-    type: 'regular',
-    date: new Date(new Date().setHours(20, 0, 0, 0)), 
-    participants: [mockMembers[0], mockMembers[1], mockMembers[2]],
-    maxParticipants: 4,
-    isCompleted: false,
+    id: '1',
+    title: 'Case 1: [방장] 모집중',
+    dateStr: '02.20',
+    timeStr: '20:00',
+    fullDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 24), // 1일 뒤
+    hostId: '1', // 나
+    maxMembers: 4,
+    participants: [
+      { user: mockMembers[0], status: 'JOIN' }, // 나
+      { user: mockMembers[1], status: 'JOIN' },
+    ],
+    isFeedbackDone: false,
   },
+  // Case 2: [멤버] 신청 완료 (참여 확정 상태)
   {
-    id: 2,
-    title: '리그 5인 랭크',
-    type: 'instant',
-    date: new Date(new Date().setDate(new Date().getDate() + 1)),
-    participants: [mockMembers[1], mockMembers[3]],
-    maxParticipants: 5,
-    isCompleted: false,
+    id: '2',
+    title: 'Case 2: [멤버] 신청 완료',
+    dateStr: '02.21',
+    timeStr: '19:00',
+    fullDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 48), // 2일 뒤
+    hostId: '2', // 다른 사람
+    maxMembers: 5,
+    participants: [
+      { user: mockMembers[1], status: 'JOIN' }, 
+      { user: mockMembers[0], status: 'JOIN' }, // 나 (참여)
+    ],
+    isFeedbackDone: false,
   },
+  // Case 3: [멤버] 거절함 (불참 선택)
   {
-    id: 3,
-    title: '발로란트 5인 스크림',
-    type: 'regular',
-    date: new Date(new Date().setDate(new Date().getDate() + 2)),
-    participants: [mockMembers[2], mockMembers[4]],
-    maxParticipants: 5,
-    isCompleted: false,
+    id: '3',
+    title: 'Case 3: [멤버] 거절함',
+    dateStr: '02.22',
+    timeStr: '21:00',
+    fullDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 72), // 3일 뒤
+    hostId: '2',
+    maxMembers: 5,
+    participants: [
+      { user: mockMembers[1], status: 'JOIN' },
+      { user: mockMembers[0], status: 'DECLINE' }, // 나 (거절)
+    ],
+    isFeedbackDone: false,
+  },
+  // Case 4: [멤버] 참여/불참 선택 전 (PENDING)
+  {
+    id: '4',
+    title: 'Case 4: [멤버] 참여/불참 대기',
+    dateStr: '02.23',
+    timeStr: '22:00',
+    fullDate: new Date(new Date().getTime() + 1000 * 60 * 60 * 96), // 4일 뒤
+    hostId: '3',
+    maxMembers: 4,
+    participants: [
+      { user: mockMembers[2], status: 'JOIN' },
+      // 나는 명단에 없거나 PENDING 상태
+      { user: mockMembers[0], status: 'PENDING' }, 
+    ],
+    isFeedbackDone: false,
+  },
+  // Case 5: [공통] 추가 게이머 찾기 (시간 종료 + 인원 미달)
+  {
+    id: '5',
+    title: 'Case 5: 시간 종료 & 인원 미달',
+    dateStr: '오늘',
+    timeStr: '18:00',
+    fullDate: new Date(new Date().getTime() - 1000 * 60 * 60), // 1시간 전 (시간 지남)
+    hostId: '2',
+    maxMembers: 5, // 목표 5명
+    participants: [
+      { user: mockMembers[1], status: 'JOIN' },
+      { user: mockMembers[2], status: 'JOIN' },
+      // 2명밖에 없음 -> 미달
+    ],
+    isFeedbackDone: false,
+  },
+  // Case 6: [공통] 피드백 남기기 (시간 종료 + 인원 충족)
+  {
+    id: '6',
+    title: 'Case 6: 정상 종료 (피드백)',
+    dateStr: '오늘',
+    timeStr: '14:00',
+    fullDate: new Date(new Date().getTime() - 1000 * 60 * 60 * 5), // 5시간 전
+    hostId: '2',
+    maxMembers: 2,
+    participants: [
+      { user: mockMembers[1], status: 'JOIN' },
+      { user: mockMembers[0], status: 'JOIN' },
+    ],
+    isFeedbackDone: false,
+  },
+  // Case 7: [공통] 완료됨 (피드백까지 끝남)
+  {
+    id: '7',
+    title: 'Case 7: 모든 절차 완료',
+    dateStr: '어제',
+    timeStr: '20:00',
+    fullDate: new Date(new Date().getTime() - 1000 * 60 * 60 * 24), // 어제
+    hostId: '1',
+    maxMembers: 4,
+    participants: [
+      { user: mockMembers[0], status: 'JOIN' },
+    ],
+    isFeedbackDone: true, // 완료됨
   },
 ];
 
 export const mockSchedulesByAzit: Record<number, Schedule[]> = {
-  1: [
-    {
-      id: 1,
-      title: '데바데 4인큐',
-      type: 'regular',
-      date: new Date(new Date().setHours(20, 0, 0, 0)),
-      participants: [mockMembers[0], mockMembers[1], mockMembers[2]],
-      maxParticipants: 4,
-      isCompleted: false,
-    },
-  ],
-  2: [
-    {
-      id: 2,
-      title: '리그 5인 랭크',
-      type: 'instant',
-      date: new Date(new Date().setDate(new Date().getDate() + 1)),
-      participants: [mockMembers[1], mockMembers[3]],
-      maxParticipants: 5,
-      isCompleted: false,
-    },
-  ],
-  3: [
-    {
-      id: 3,
-      title: '발로란트 5인 스크림',
-      type: 'regular',
-      date: new Date(new Date().setDate(new Date().getDate() + 2)),
-      participants: [mockMembers[2], mockMembers[4]],
-      maxParticipants: 5,
-      isCompleted: false,
-    },
-  ],
+  1: mockSchedules,
+  2: [],
+  3: [],
 };
 
-// 음성/채팅 채널 목록
+// ... (채널, 클립 데이터는 기존과 동일하게 유지)
 export const mockVoiceChannels: Channel[] = [
-  {
-    id: 1,
-    name: '로비',
-    type: 'voice',
-    category: 'lobby',
-    participants: [],
-  },
-  {
-    id: 2,
-    name: '스크림 룸',
-    type: 'voice',
-    category: 'game',
-    participants: [mockMembers[0], mockMembers[1]], // 참여중
-  },
-  {
-    id: 3,
-    name: '팀 채팅',
-    type: 'text',
-    category: 'chat',
-    participants: [],
-  },
-  {
-    id: 4,
-    name: '수다방',
-    type: 'text',
-    category: 'chat',
-    participants: [],
-  },
+  { id: '1', name: '로비', type: 'VOICE', connectedUsers: [] },
+  { id: '2', name: '스크림 룸', type: 'VOICE', connectedUsers: [mockMembers[0], mockMembers[1]] },
 ];
 
-// 하이라이트 클립 목록
 export const mockClips: Clip[] = [
-  {
-    id: 1,
-    title: '펜타킬 하이라이트',
-    author: '레나',
-    thumbnailUrl: 'https://via.placeholder.com/300x160/000000/FFFFFF?text=PentaKill',
-    views: 120,
-    duration: '0:45',
-    createdAt: '2시간 전',
-  },
-  {
-    id: 2,
-    title: '아니 이걸 못 잡아?',
-    author: '엘릭',
-    thumbnailUrl: 'https://via.placeholder.com/300x160/333333/FFFFFF?text=Fail',
-    views: 55,
-    duration: '0:12',
-    createdAt: '1일 전',
-  },
-  {
-    id: 3,
-    title: '슈퍼 세이브',
-    author: '모모',
-    thumbnailUrl: 'https://via.placeholder.com/300x160/1e293b/FFFFFF?text=SuperSave',
-    views: 89,
-    duration: '1:20',
-    createdAt: '3일 전',
-  },
+  { id: '1', date: '2시간 전', thumbnailUrl: 'https://via.placeholder.com/300x160/000000/FFFFFF?text=PentaKill' },
 ];
-
-export const mockClipsByAzit: Record<number, Clip[]> = {
-  1: [
-    {
-      id: 1,
-      title: '펜타킬 하이라이트',
-      author: '레나',
-      thumbnailUrl: 'https://via.placeholder.com/300x160/000000/FFFFFF?text=PentaKill',
-      views: 120,
-      duration: '0:45',
-      createdAt: '2시간 전',
-    },
-  ],
-  2: [
-    {
-      id: 2,
-      title: '리그 역전 하이라이트',
-      author: '로이',
-      thumbnailUrl: 'https://via.placeholder.com/300x160/2563eb/FFFFFF?text=LoL',
-      views: 210,
-      duration: '1:05',
-      createdAt: '5시간 전',
-    },
-  ],
-  3: [
-    {
-      id: 3,
-      title: '스터디 밈 모음',
-      author: '수지',
-      thumbnailUrl: 'https://via.placeholder.com/300x160/16a34a/FFFFFF?text=Study',
-      views: 45,
-      duration: '0:30',
-      createdAt: '어제',
-    },
-  ],
-};
+export const mockClipsByAzit: Record<number, Clip[]> = { 1: mockClips, 2: [], 3: [] };

--- a/Playproof/src/features/team/hooks/useAzitChat.ts
+++ b/Playproof/src/features/team/hooks/useAzitChat.ts
@@ -3,17 +3,31 @@ import { useState, useRef, ChangeEvent } from 'react';
 export const useAzitChat = () => {
   const [message, setMessage] = useState('');
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
+  const [previewItems, setPreviewItems] = useState<{ url: string; type: "image" | "video" }[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const MAX_FILES = 10;
 
   // 파일 선택
   const handleFileSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
     if (files.length === 0) return;
 
-    setSelectedFiles((prev) => [...prev, ...files]);
-    const newPreviewUrls = files.map((file) => URL.createObjectURL(file));
-    setPreviewUrls((prev) => [...prev, ...newPreviewUrls]);
+    let nextFiles: File[] = [];
+    setSelectedFiles((prev) => {
+      const remaining = MAX_FILES - prev.length;
+      if (remaining <= 0) {
+        return prev;
+      }
+      nextFiles = files.slice(0, remaining);
+      return [...prev, ...nextFiles];
+    });
+    if (nextFiles.length > 0) {
+      const newPreviewItems = nextFiles.map((file) => ({
+        url: URL.createObjectURL(file),
+        type: file.type.startsWith("video/") ? "video" : "image",
+      }));
+      setPreviewItems((prev) => [...prev, ...newPreviewItems]);
+    }
     
     // 같은 파일 재선택 가능하도록 초기화
     e.target.value = '';
@@ -22,8 +36,8 @@ export const useAzitChat = () => {
   // 이미지 삭제
   const handleRemoveImage = (indexToRemove: number) => {
     setSelectedFiles((prev) => prev.filter((_, index) => index !== indexToRemove));
-    setPreviewUrls((prev) => {
-      URL.revokeObjectURL(prev[indexToRemove]); // 메모리 해제
+    setPreviewItems((prev) => {
+      URL.revokeObjectURL(prev[indexToRemove].url); // 메모리 해제
       return prev.filter((_, index) => index !== indexToRemove);
     });
   };
@@ -42,8 +56,8 @@ export const useAzitChat = () => {
     // 초기화
     setMessage('');
     setSelectedFiles([]);
-    setPreviewUrls((prev) => {
-      prev.forEach(url => URL.revokeObjectURL(url));
+    setPreviewItems((prev) => {
+      prev.forEach((item) => URL.revokeObjectURL(item.url));
       return [];
     });
   };
@@ -51,7 +65,8 @@ export const useAzitChat = () => {
   return {
     message,
     setMessage,
-    previewUrls,
+    selectedFiles,
+    previewItems,
     fileInputRef,
     handleFileSelect,
     handleRemoveImage,

--- a/Playproof/src/features/team/hooks/useAzitFeedback.ts
+++ b/Playproof/src/features/team/hooks/useAzitFeedback.ts
@@ -1,0 +1,120 @@
+import React from "react";
+import type { Schedule, User } from "@/features/team/types/types";
+import { getScheduleActionState } from "@/features/team/utils/scheduleAction";
+import {
+  addPendingFeedback,
+  getPendingFeedbacks,
+  removePendingFeedback,
+} from "@/features/team/utils/pendingFeedback";
+
+type FeedbackModalState = {
+  open: boolean;
+  scheduleId?: string;
+  targetName?: string;
+  targetMeta?: string;
+  avatarUrl?: string;
+  required?: boolean;
+};
+
+type UseAzitFeedbackParams = {
+  schedules: Schedule[];
+  currentUserId: string;
+  currentUser: User;
+  currentAzitId: number;
+  markFeedbackDone: (scheduleId: string) => void;
+};
+
+export const useAzitFeedback = ({
+  schedules,
+  currentUserId,
+  currentUser,
+  currentAzitId,
+  markFeedbackDone,
+}: UseAzitFeedbackParams) => {
+  const [feedbackModal, setFeedbackModal] = React.useState<FeedbackModalState>({
+    open: false,
+  });
+
+  const getFeedbackTargetName = React.useCallback(
+    (scheduleId: string) => {
+      const targetSchedule = schedules.find((sch) => sch.id === scheduleId);
+      if (!targetSchedule) return "상대방";
+      const target =
+        targetSchedule.participants.find(
+          (p) => String(p.user?.id) !== String(currentUser.id)
+        )?.user ?? targetSchedule.participants[0]?.user;
+      return target?.nickname ?? "상대방";
+    },
+    [currentUser.id, schedules]
+  );
+
+  const getFeedbackTargetMeta = React.useCallback(
+    (scheduleId: string) => {
+      const targetSchedule = schedules.find((sch) => sch.id === scheduleId);
+      if (!targetSchedule) return "Tier TS 90";
+      const target =
+        targetSchedule.participants.find(
+          (p) => String(p.user?.id) !== String(currentUser.id)
+        )?.user ?? targetSchedule.participants[0]?.user;
+      if (!target) return "Tier TS 90";
+      return "Tier TS 90";
+    },
+    [currentUser.id, schedules]
+  );
+
+  const openFeedbackModal = React.useCallback(
+    (scheduleId: string, required = false) => {
+      const targetName = getFeedbackTargetName(scheduleId);
+      const targetMeta = getFeedbackTargetMeta(scheduleId);
+      const targetSchedule = schedules.find((sch) => sch.id === scheduleId);
+      const target =
+        targetSchedule?.participants.find(
+          (p) => String(p.user?.id) !== String(currentUser.id)
+        )?.user ?? targetSchedule?.participants[0]?.user;
+      setFeedbackModal({
+        open: true,
+        scheduleId,
+        targetName,
+        targetMeta,
+        avatarUrl: target?.avatarUrl,
+        required,
+      });
+    },
+    [currentUser.id, getFeedbackTargetMeta, getFeedbackTargetName, schedules]
+  );
+
+  const closeFeedbackModal = React.useCallback(() => {
+    setFeedbackModal({ open: false });
+  }, []);
+
+  React.useEffect(() => {
+    schedules.forEach((schedule) => {
+      const action = getScheduleActionState(schedule, currentUserId);
+      if (action.status !== "TIME_OVER" || schedule.isFeedbackDone) return;
+      const targetName = getFeedbackTargetName(schedule.id);
+      addPendingFeedback({
+        scheduleId: schedule.id,
+        azitId: currentAzitId,
+        targetName,
+        scheduleTitle: schedule.title,
+      });
+    });
+  }, [currentAzitId, currentUserId, getFeedbackTargetName, schedules]);
+
+  const submitFeedback = React.useCallback(
+    (scheduleId: string) => {
+      markFeedbackDone(scheduleId);
+      removePendingFeedback(scheduleId, currentAzitId);
+      setFeedbackModal({ open: false });
+    },
+    [currentAzitId, markFeedbackDone]
+  );
+
+  return {
+    feedbackModal,
+    openFeedbackModal,
+    closeFeedbackModal,
+    submitFeedback,
+    getPendingFeedbacks,
+  };
+};

--- a/Playproof/src/features/team/hooks/useAzitMedia.ts
+++ b/Playproof/src/features/team/hooks/useAzitMedia.ts
@@ -1,0 +1,85 @@
+import React from "react";
+import type { Clip } from "@/types";
+
+type MediaItem = { url: string; type: "image" | "video" };
+
+const formatDuration = (seconds: number) => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
+  const total = Math.round(seconds);
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+};
+
+export const useAzitMedia = (initialClips: Record<number, Clip[]>) => {
+  const [clipsByAzit, setClipsByAzit] = React.useState<Record<number, Clip[]>>(
+    initialClips
+  );
+  const mediaUrlsRef = React.useRef<string[]>([]);
+
+  const createMediaItems = React.useCallback((files: File[]) => {
+    const media = files.map((file) => ({
+      url: URL.createObjectURL(file),
+      type: file.type.startsWith("video/") ? ("video" as const) : ("image" as const),
+    }));
+    if (media.length > 0) {
+      mediaUrlsRef.current.push(...media.map((item) => item.url));
+    }
+    return media;
+  }, []);
+
+  const addClipsFromMedia = React.useCallback((azitId: number, media: MediaItem[]) => {
+    if (media.length === 0) return;
+    const nowLabel = "방금 전";
+    const newClips: Clip[] = media.map((item, index) => ({
+      id: `${Date.now()}-${index}`,
+      date: nowLabel,
+      thumbnailUrl: item.type === "image" ? item.url : "",
+      mediaType: item.type,
+      mediaUrl: item.url,
+      durationLabel: item.type === "video" ? "0:00" : undefined,
+    }));
+
+    setClipsByAzit((prev) => {
+      const current = prev[azitId] ?? [];
+      return { ...prev, [azitId]: [...newClips, ...current] };
+    });
+
+    newClips.forEach((clip) => {
+      if (clip.mediaType !== "video" || !clip.mediaUrl) return;
+      const video = document.createElement("video");
+      video.preload = "metadata";
+      video.src = clip.mediaUrl;
+      video.onloadedmetadata = () => {
+        const label = formatDuration(video.duration);
+        setClipsByAzit((prev) => {
+          const current = prev[azitId] ?? [];
+          return {
+            ...prev,
+            [azitId]: current.map((item) =>
+              item.id === clip.id ? { ...item, durationLabel: label } : item
+            ),
+          };
+        });
+      };
+    });
+  }, []);
+
+  const initAzitClips = React.useCallback((azitId: number) => {
+    setClipsByAzit((prev) => ({ ...prev, [azitId]: [] }));
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      mediaUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+      mediaUrlsRef.current = [];
+    };
+  }, []);
+
+  return {
+    clipsByAzit,
+    createMediaItems,
+    addClipsFromMedia,
+    initAzitClips,
+  };
+};

--- a/Playproof/src/features/team/hooks/useAzitMediaViewer.ts
+++ b/Playproof/src/features/team/hooks/useAzitMediaViewer.ts
@@ -1,0 +1,73 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import type { Clip } from "@/types";
+
+export const useAzitMediaViewer = (clips: Clip[]) => {
+  const [isGalleryOpen, setIsGalleryOpen] = React.useState(false);
+  const [activeMedia, setActiveMedia] = React.useState<Clip | null>(null);
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const navigate = useNavigate();
+  const hasMedia = clips.length > 0;
+
+  const closeGallery = React.useCallback(() => {
+    setIsGalleryOpen(false);
+  }, []);
+
+  const openMedia = React.useCallback((clip: Clip, index: number) => {
+    setActiveMedia(clip);
+    setActiveIndex(index);
+  }, []);
+
+  const closeMedia = React.useCallback(() => {
+    setActiveMedia(null);
+  }, []);
+
+  const goPrev = React.useCallback(() => {
+    if (!hasMedia) return;
+    const nextIndex = (activeIndex - 1 + clips.length) % clips.length;
+    setActiveIndex(nextIndex);
+    setActiveMedia(clips[nextIndex]);
+  }, [activeIndex, clips, hasMedia]);
+
+  const goNext = React.useCallback(() => {
+    if (!hasMedia) return;
+    const nextIndex = (activeIndex + 1) % clips.length;
+    setActiveIndex(nextIndex);
+    setActiveMedia(clips[nextIndex]);
+  }, [activeIndex, clips, hasMedia]);
+
+  const goHighlight = React.useCallback(() => {
+    navigate("/community?tab=하이라이트");
+  }, [navigate]);
+
+  const shareToHighlight = React.useCallback(async () => {
+    if (!activeMedia) return;
+    if (activeMedia.mediaType === "video") {
+      alert("영상 공유는 아직 준비 중이에요.");
+      return;
+    }
+    const sourceUrl = activeMedia.mediaUrl ?? activeMedia.thumbnailUrl;
+    if (!sourceUrl) return;
+    const response = await fetch(sourceUrl);
+    const blob = await response.blob();
+    const ext = blob.type.includes("png") ? "png" : "jpg";
+    const file = new File([blob], `highlight-share-${Date.now()}.${ext}`, {
+      type: blob.type || "image/jpeg",
+    });
+    navigate("/community?tab=하이라이트", { state: { shareFiles: [file] } });
+  }, [activeMedia, navigate]);
+
+  return {
+    isGalleryOpen,
+    activeMedia,
+    activeIndex,
+    hasMedia,
+    closeGallery,
+    openMedia,
+    closeMedia,
+    goPrev,
+    goNext,
+    goHighlight,
+    shareToHighlight,
+  };
+};

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -1,0 +1,55 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+import {
+  MOCK_MY_AZITS,
+  mockClipsByAzit,
+  mockMembersByAzit,
+  mockSchedulesByAzit,
+} from "@/features/team/data/mockTeamData";
+import { useAzitSchedules } from "@/features/team/hooks/useAzitSchedules";
+
+const FALLBACK_USER_ID = "1";
+
+export function useAzitPageLogic() {
+  const location = useLocation();
+  const state = location.state as { azitId?: number } | null;
+  const [scheduleAnchorEl, setScheduleAnchorEl] = React.useState<HTMLElement | null>(null);
+  const currentUserId = FALLBACK_USER_ID;
+
+  const {
+    currentAzitId,
+    setCurrentAzitId,
+    schedules,
+    handleStatusChange,
+  } = useAzitSchedules(currentUserId, mockSchedulesByAzit, mockMembersByAzit);
+
+  React.useEffect(() => {
+    if (state?.azitId) {
+      setCurrentAzitId(state.azitId);
+    }
+  }, [state?.azitId, setCurrentAzitId]);
+
+  const currentAzit =
+    MOCK_MY_AZITS.find((azit) => azit.id === currentAzitId) ?? MOCK_MY_AZITS[0];
+  const currentMembers =
+    mockMembersByAzit[currentAzitId] ?? mockMembersByAzit[1];
+  const currentClips = mockClipsByAzit[currentAzitId] ?? mockClipsByAzit[1];
+
+  return {
+    state: {
+      azits: MOCK_MY_AZITS,
+      currentAzitId,
+      scheduleAnchorEl,
+      currentAzit,
+      currentMembers,
+      currentClips,
+      schedules,
+      currentUserId,
+    },
+    actions: {
+      setCurrentAzitId,
+      setScheduleAnchorEl,
+      handleStatusChange,
+    },
+  };
+}

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -1,7 +1,10 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
+import type { User } from "@/features/team/types/types";
+import type { Clip } from "@/types";
 import {
   MOCK_MY_AZITS,
+  mockMembers,
   mockClipsByAzit,
   mockMembersByAzit,
   mockSchedulesByAzit,
@@ -9,19 +12,79 @@ import {
 import { useAzitSchedules } from "@/features/team/hooks/useAzitSchedules";
 
 const FALLBACK_USER_ID = "1";
+const createDefaultVoiceRooms = () => [
+  { id: "voice-lobby", name: "로비", users: [] as User[] },
+];
+
+type ChatMessage = {
+  id: string;
+  author: string;
+  content: string;
+  createdAt: string;
+  media?: { url: string; type: "image" | "video" }[];
+};
+
+const createDefaultTextRooms = () => ["자유 대화"];
+const formatDuration = (seconds: number) => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
+  const total = Math.round(seconds);
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+};
 
 export function useAzitPageLogic() {
   const location = useLocation();
   const state = location.state as { azitId?: number } | null;
   const [scheduleAnchorEl, setScheduleAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [azits, setAzits] = React.useState(MOCK_MY_AZITS);
+  const azitIconUrlsRef = React.useRef<string[]>([]);
+  const [selectedChatRoomByAzit, setSelectedChatRoomByAzit] = React.useState<Record<number, string>>({
+    1: "자유 대화",
+    2: "자유 대화",
+    3: "자유 대화",
+  });
+  const [textRoomsByAzit, setTextRoomsByAzit] = React.useState<Record<number, string[]>>({
+    1: createDefaultTextRooms(),
+    2: createDefaultTextRooms(),
+    3: createDefaultTextRooms(),
+  });
+  const [messagesByAzit, setMessagesByAzit] = React.useState<
+    Record<number, Record<string, ChatMessage[]>>
+  >({
+    1: { "자유 대화": [] },
+    2: { "자유 대화": [] },
+    3: { "자유 대화": [] },
+  });
+  const messageMediaRef = React.useRef<string[]>([]);
+  const [voiceRoomsByAzit, setVoiceRoomsByAzit] = React.useState<
+    Record<number, { id: string; name: string; users: User[] }[]>
+  >({
+    1: createDefaultVoiceRooms(),
+    2: createDefaultVoiceRooms(),
+    3: createDefaultVoiceRooms(),
+  });
+  const [clipsByAzit, setClipsByAzit] = React.useState<Record<number, Clip[]>>(
+    mockClipsByAzit
+  );
   const currentUserId = FALLBACK_USER_ID;
+
+  const currentUser =
+    mockMembers.find((member) => String(member.id) === String(currentUserId)) ??
+    ({
+      id: String(currentUserId),
+      nickname: "사용자",
+      avatarUrl: "",
+      isOnline: true,
+    } as User);
 
   const {
     currentAzitId,
     setCurrentAzitId,
     schedules,
     handleStatusChange,
-  } = useAzitSchedules(currentUserId, mockSchedulesByAzit, mockMembersByAzit);
+    addSchedule,
+  } = useAzitSchedules(currentUserId, mockSchedulesByAzit, mockMembersByAzit, currentUser);
 
   React.useEffect(() => {
     if (state?.azitId) {
@@ -29,27 +92,332 @@ export function useAzitPageLogic() {
     }
   }, [state?.azitId, setCurrentAzitId]);
 
-  const currentAzit =
-    MOCK_MY_AZITS.find((azit) => azit.id === currentAzitId) ?? MOCK_MY_AZITS[0];
-  const currentMembers =
-    mockMembersByAzit[currentAzitId] ?? mockMembersByAzit[1];
-  const currentClips = mockClipsByAzit[currentAzitId] ?? mockClipsByAzit[1];
+  const currentAzit = azits.find((azit) => azit.id === currentAzitId) ?? azits[0];
+  const currentMembers = mockMembersByAzit[currentAzitId] ?? [];
+  const currentClips = clipsByAzit[currentAzitId] ?? [];
+  const selectedChatRoom = selectedChatRoomByAzit[currentAzitId] ?? "자유 대화";
+  const voiceRooms = voiceRoomsByAzit[currentAzitId] ?? createDefaultVoiceRooms();
+  const textRooms = textRoomsByAzit[currentAzitId] ?? createDefaultTextRooms();
+  const messages = messagesByAzit[currentAzitId]?.[selectedChatRoom] ?? [];
+
+  const setSelectedChatRoom = React.useCallback(
+    (roomName: string) => {
+      setSelectedChatRoomByAzit((prev) => ({ ...prev, [currentAzitId]: roomName }));
+    },
+    [currentAzitId]
+  );
+
+  const addChatRoom = React.useCallback(
+    (name: string, type: "TEXT" | "VOICE") => {
+      if (!name.trim()) return;
+      if (type === "TEXT") {
+        setTextRoomsByAzit((prev) => {
+          const currentRooms = prev[currentAzitId] ?? [];
+          if (currentRooms.includes(name)) return prev;
+          return { ...prev, [currentAzitId]: [name, ...currentRooms] };
+        });
+        setMessagesByAzit((prev) => {
+          const currentAzitMessages = prev[currentAzitId] ?? {};
+          if (currentAzitMessages[name]) return prev;
+          return {
+            ...prev,
+            [currentAzitId]: { ...currentAzitMessages, [name]: [] },
+          };
+        });
+        setSelectedChatRoomByAzit((prev) => ({ ...prev, [currentAzitId]: name }));
+        return;
+      }
+
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
+        if (currentRooms.some((room) => room.name === name)) return prev;
+        const nextRooms = [
+          { id: `voice-${Date.now()}`, name, users: [] as User[] },
+          ...currentRooms,
+        ];
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+    },
+    [currentAzitId]
+  );
+
+  const renameVoiceRoom = React.useCallback(
+    (roomId: string, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed) return;
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
+        if (currentRooms.some((room) => room.name === trimmed)) {
+          return prev;
+        }
+        const nextRooms = currentRooms.map((room) =>
+          room.id === roomId ? { ...room, name: trimmed } : room
+        );
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+    },
+    [currentAzitId]
+  );
+
+  const deleteVoiceRoom = React.useCallback(
+    (roomId: string) => {
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
+        if (currentRooms.length <= 1) return prev;
+        const nextRooms = currentRooms.filter((room) => room.id !== roomId);
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+    },
+    [currentAzitId]
+  );
+
+  const renameChatRoom = React.useCallback(
+    (roomName: string, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed || trimmed === roomName) return;
+
+      let duplicate = false;
+      setTextRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? [];
+        if (currentRooms.includes(trimmed)) {
+          duplicate = true;
+          return prev;
+        }
+        const updatedRooms = currentRooms.map((room) =>
+          room === roomName ? trimmed : room
+        );
+        return { ...prev, [currentAzitId]: updatedRooms };
+      });
+      if (duplicate) return;
+
+      setMessagesByAzit((prev) => {
+        const currentAzitMessages = prev[currentAzitId] ?? {};
+        if (currentAzitMessages[trimmed]) return prev;
+        const { [roomName]: roomMessages, ...rest } = currentAzitMessages;
+        return {
+          ...prev,
+          [currentAzitId]: {
+            ...rest,
+            [trimmed]: roomMessages ?? [],
+          },
+        };
+      });
+
+      setSelectedChatRoomByAzit((prev) =>
+        prev[currentAzitId] === roomName
+          ? { ...prev, [currentAzitId]: trimmed }
+          : prev
+      );
+    },
+    [currentAzitId]
+  );
+
+  const deleteChatRoom = React.useCallback(
+    (roomName: string) => {
+      setTextRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? [];
+        if (currentRooms.length <= 1) return prev;
+        const nextRooms = currentRooms.filter((room) => room !== roomName);
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+
+      setMessagesByAzit((prev) => {
+        const currentAzitMessages = prev[currentAzitId] ?? {};
+        const { [roomName]: _removed, ...rest } = currentAzitMessages;
+        return {
+          ...prev,
+          [currentAzitId]: Object.keys(rest).length > 0 ? rest : { "자유 대화": [] },
+        };
+      });
+
+      setSelectedChatRoomByAzit((prev) => {
+        if (prev[currentAzitId] !== roomName) return prev;
+        const rooms = textRoomsByAzit[currentAzitId] ?? [];
+        const nextRooms = rooms.filter((room) => room !== roomName);
+        const fallback = nextRooms[0] ?? "자유 대화";
+        return { ...prev, [currentAzitId]: fallback };
+      });
+    },
+    [currentAzitId, textRoomsByAzit]
+  );
+
+  const addChatMessage = React.useCallback(
+    (roomName: string, content: string, files: File[]) => {
+      const text = content.trim();
+      if (!text && files.length === 0) return;
+
+      const media = files.map((file) => ({
+        url: URL.createObjectURL(file),
+        type: file.type.startsWith("video/") ? ("video" as const) : ("image" as const),
+      }));
+
+      if (media.length > 0) {
+        messageMediaRef.current.push(...media.map((item) => item.url));
+      }
+
+      const newMessage: ChatMessage = {
+        id: `${Date.now()}`,
+        author: currentUser.nickname,
+        content: text,
+        createdAt: "방금 전",
+        media: media.length > 0 ? media : undefined,
+      };
+
+      setMessagesByAzit((prev) => {
+        const currentAzitMessages = prev[currentAzitId] ?? {};
+        const roomMessages = currentAzitMessages[roomName] ?? [];
+        return {
+          ...prev,
+          [currentAzitId]: {
+            ...currentAzitMessages,
+            [roomName]: [newMessage, ...roomMessages],
+          },
+        };
+      });
+
+      if (media.length > 0) {
+        const nowLabel = "방금 전";
+        const newClips: Clip[] = media.map((item, index) => ({
+          id: `${Date.now()}-${index}`,
+          date: nowLabel,
+          thumbnailUrl: item.type === "image" ? item.url : "",
+          mediaType: item.type,
+          mediaUrl: item.url,
+          durationLabel: item.type === "video" ? "0:00" : undefined,
+        }));
+
+        setClipsByAzit((prev) => {
+          const current = prev[currentAzitId] ?? [];
+          return {
+            ...prev,
+            [currentAzitId]: [...newClips, ...current],
+          };
+        });
+
+        newClips.forEach((clip) => {
+          if (clip.mediaType !== "video" || !clip.mediaUrl) return;
+          const video = document.createElement("video");
+          video.preload = "metadata";
+          video.src = clip.mediaUrl;
+          video.onloadedmetadata = () => {
+            const label = formatDuration(video.duration);
+            setClipsByAzit((prev) => {
+              const current = prev[currentAzitId] ?? [];
+              return {
+                ...prev,
+                [currentAzitId]: current.map((item) =>
+                  item.id === clip.id ? { ...item, durationLabel: label } : item
+                ),
+              };
+            });
+          };
+        });
+      }
+    },
+    [currentAzitId, currentUser.nickname]
+  );
+
+  React.useEffect(() => {
+    return () => {
+      messageMediaRef.current.forEach((url) => URL.revokeObjectURL(url));
+      messageMediaRef.current = [];
+      azitIconUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+      azitIconUrlsRef.current = [];
+    };
+  }, []);
+
+  const joinVoiceRoom = React.useCallback(
+    (roomId: string) => {
+      const me = currentUser;
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? [];
+        const hadMeInTarget = currentRooms.some(
+          (room) =>
+            room.id === roomId &&
+            room.users.some((user) => String(user.id) === String(me.id))
+        );
+
+        const nextState: Record<number, { id: string; name: string; users: User[] }[]> = {};
+
+        Object.entries(prev).forEach(([azitKey, rooms]) => {
+          nextState[Number(azitKey)] = rooms.map((room) => ({
+            ...room,
+            users: room.users.filter((user) => String(user.id) !== String(me.id)),
+          }));
+        });
+
+        if (!hadMeInTarget) {
+          const targetRooms = nextState[currentAzitId] ?? createDefaultVoiceRooms();
+          nextState[currentAzitId] = targetRooms.map((room) =>
+            room.id === roomId ? { ...room, users: [...room.users, me] } : room
+          );
+        }
+
+        return nextState;
+      });
+    },
+    [currentAzitId, currentUser]
+  );
+
+  const addAzit = React.useCallback(
+    (name: string, iconUrl?: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const nextId =
+        azits.reduce((max, azit) => Math.max(max, azit.id), 0) + 1;
+      if (iconUrl) {
+        azitIconUrlsRef.current.push(iconUrl);
+      }
+      const nextAzit = {
+        id: nextId,
+        name: trimmed,
+        memberCount: 1,
+        icon: iconUrl ?? "",
+      };
+      setAzits((prev) => [...prev, nextAzit]);
+      setSelectedChatRoomByAzit((prev) => ({ ...prev, [nextId]: "자유 대화" }));
+      setTextRoomsByAzit((prev) => ({ ...prev, [nextId]: createDefaultTextRooms() }));
+      setMessagesByAzit((prev) => ({
+        ...prev,
+        [nextId]: { "자유 대화": [] },
+      }));
+      setVoiceRoomsByAzit((prev) => ({ ...prev, [nextId]: createDefaultVoiceRooms() }));
+      setClipsByAzit((prev) => ({ ...prev, [nextId]: [] }));
+      setCurrentAzitId(nextId);
+    },
+    [azits, setCurrentAzitId]
+  );
 
   return {
     state: {
-      azits: MOCK_MY_AZITS,
+      azits,
       currentAzitId,
       scheduleAnchorEl,
+      selectedChatRoom,
+      voiceRooms,
+      messages,
+      textRooms,
       currentAzit,
       currentMembers,
       currentClips,
       schedules,
       currentUserId,
+      currentUser,
     },
     actions: {
       setCurrentAzitId,
       setScheduleAnchorEl,
+      setSelectedChatRoom,
+      joinVoiceRoom,
       handleStatusChange,
+      addSchedule,
+      addChatRoom,
+      renameVoiceRoom,
+      deleteVoiceRoom,
+      renameChatRoom,
+      deleteChatRoom,
+      addChatMessage,
+      addAzit,
     },
   };
 }

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -1,7 +1,6 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
 import type { User } from "@/features/team/types/types";
-import type { Clip } from "@/types";
 import {
   MOCK_MY_AZITS,
   mockMembers,
@@ -10,63 +9,17 @@ import {
   mockSchedulesByAzit,
 } from "@/features/team/data/mockTeamData";
 import { useAzitSchedules } from "@/features/team/hooks/useAzitSchedules";
+import { useAzitFeedback } from "@/features/team/hooks/useAzitFeedback";
+import { useAzitMedia } from "@/features/team/hooks/useAzitMedia";
+import { useAzitRooms } from "@/features/team/hooks/useAzitRooms";
 
 const FALLBACK_USER_ID = "1";
-const createDefaultVoiceRooms = () => [
-  { id: "voice-lobby", name: "로비", users: [] as User[] },
-];
-
-type ChatMessage = {
-  id: string;
-  author: string;
-  content: string;
-  createdAt: string;
-  media?: { url: string; type: "image" | "video" }[];
-};
-
-const createDefaultTextRooms = () => ["자유 대화"];
-const formatDuration = (seconds: number) => {
-  if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
-  const total = Math.round(seconds);
-  const mins = Math.floor(total / 60);
-  const secs = total % 60;
-  return `${mins}:${String(secs).padStart(2, "0")}`;
-};
-
 export function useAzitPageLogic() {
   const location = useLocation();
   const state = location.state as { azitId?: number } | null;
   const [scheduleAnchorEl, setScheduleAnchorEl] = React.useState<HTMLElement | null>(null);
   const [azits, setAzits] = React.useState(MOCK_MY_AZITS);
   const azitIconUrlsRef = React.useRef<string[]>([]);
-  const [selectedChatRoomByAzit, setSelectedChatRoomByAzit] = React.useState<Record<number, string>>({
-    1: "자유 대화",
-    2: "자유 대화",
-    3: "자유 대화",
-  });
-  const [textRoomsByAzit, setTextRoomsByAzit] = React.useState<Record<number, string[]>>({
-    1: createDefaultTextRooms(),
-    2: createDefaultTextRooms(),
-    3: createDefaultTextRooms(),
-  });
-  const [messagesByAzit, setMessagesByAzit] = React.useState<
-    Record<number, Record<string, ChatMessage[]>>
-  >({
-    1: { "자유 대화": [] },
-    2: { "자유 대화": [] },
-    3: { "자유 대화": [] },
-  });
-  const messageMediaRef = React.useRef<string[]>([]);
-  const [voiceRoomsByAzit, setVoiceRoomsByAzit] = React.useState<
-    Record<number, { id: string; name: string; users: User[] }[]>
-  >({
-    1: createDefaultVoiceRooms(),
-    2: createDefaultVoiceRooms(),
-    3: createDefaultVoiceRooms(),
-  });
-  const [clipsByAzit, setClipsByAzit] = React.useState<Record<number, Clip[]>>(
-    mockClipsByAzit
-  );
   const currentUserId = FALLBACK_USER_ID;
 
   const currentUser =
@@ -84,7 +37,41 @@ export function useAzitPageLogic() {
     schedules,
     handleStatusChange,
     addSchedule,
+    markFeedbackDone,
   } = useAzitSchedules(currentUserId, mockSchedulesByAzit, mockMembersByAzit, currentUser);
+
+  const {
+    feedbackModal,
+    openFeedbackModal,
+    closeFeedbackModal,
+    submitFeedback,
+    getPendingFeedbacks,
+  } = useAzitFeedback({
+    schedules,
+    currentUserId,
+    currentUser,
+    currentAzitId,
+    markFeedbackDone,
+  });
+
+  const { clipsByAzit, createMediaItems, addClipsFromMedia, initAzitClips } =
+    useAzitMedia(mockClipsByAzit);
+
+  const {
+    selectedChatRoom,
+    voiceRooms,
+    textRooms,
+    messages,
+    setSelectedChatRoom,
+    addChatRoom,
+    renameVoiceRoom,
+    deleteVoiceRoom,
+    renameChatRoom,
+    deleteChatRoom,
+    addChatMessage: addRoomMessage,
+    joinVoiceRoom,
+    initAzitRooms,
+  } = useAzitRooms(currentAzitId, currentUser);
 
   React.useEffect(() => {
     if (state?.azitId) {
@@ -95,269 +82,26 @@ export function useAzitPageLogic() {
   const currentAzit = azits.find((azit) => azit.id === currentAzitId) ?? azits[0];
   const currentMembers = mockMembersByAzit[currentAzitId] ?? [];
   const currentClips = clipsByAzit[currentAzitId] ?? [];
-  const selectedChatRoom = selectedChatRoomByAzit[currentAzitId] ?? "자유 대화";
-  const voiceRooms = voiceRoomsByAzit[currentAzitId] ?? createDefaultVoiceRooms();
-  const textRooms = textRoomsByAzit[currentAzitId] ?? createDefaultTextRooms();
-  const messages = messagesByAzit[currentAzitId]?.[selectedChatRoom] ?? [];
-
-  const setSelectedChatRoom = React.useCallback(
-    (roomName: string) => {
-      setSelectedChatRoomByAzit((prev) => ({ ...prev, [currentAzitId]: roomName }));
-    },
-    [currentAzitId]
-  );
-
-  const addChatRoom = React.useCallback(
-    (name: string, type: "TEXT" | "VOICE") => {
-      if (!name.trim()) return;
-      if (type === "TEXT") {
-        setTextRoomsByAzit((prev) => {
-          const currentRooms = prev[currentAzitId] ?? [];
-          if (currentRooms.includes(name)) return prev;
-          return { ...prev, [currentAzitId]: [name, ...currentRooms] };
-        });
-        setMessagesByAzit((prev) => {
-          const currentAzitMessages = prev[currentAzitId] ?? {};
-          if (currentAzitMessages[name]) return prev;
-          return {
-            ...prev,
-            [currentAzitId]: { ...currentAzitMessages, [name]: [] },
-          };
-        });
-        setSelectedChatRoomByAzit((prev) => ({ ...prev, [currentAzitId]: name }));
-        return;
-      }
-
-      setVoiceRoomsByAzit((prev) => {
-        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
-        if (currentRooms.some((room) => room.name === name)) return prev;
-        const nextRooms = [
-          { id: `voice-${Date.now()}`, name, users: [] as User[] },
-          ...currentRooms,
-        ];
-        return { ...prev, [currentAzitId]: nextRooms };
-      });
-    },
-    [currentAzitId]
-  );
-
-  const renameVoiceRoom = React.useCallback(
-    (roomId: string, nextName: string) => {
-      const trimmed = nextName.trim();
-      if (!trimmed) return;
-      setVoiceRoomsByAzit((prev) => {
-        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
-        if (currentRooms.some((room) => room.name === trimmed)) {
-          return prev;
-        }
-        const nextRooms = currentRooms.map((room) =>
-          room.id === roomId ? { ...room, name: trimmed } : room
-        );
-        return { ...prev, [currentAzitId]: nextRooms };
-      });
-    },
-    [currentAzitId]
-  );
-
-  const deleteVoiceRoom = React.useCallback(
-    (roomId: string) => {
-      setVoiceRoomsByAzit((prev) => {
-        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
-        if (currentRooms.length <= 1) return prev;
-        const nextRooms = currentRooms.filter((room) => room.id !== roomId);
-        return { ...prev, [currentAzitId]: nextRooms };
-      });
-    },
-    [currentAzitId]
-  );
-
-  const renameChatRoom = React.useCallback(
-    (roomName: string, nextName: string) => {
-      const trimmed = nextName.trim();
-      if (!trimmed || trimmed === roomName) return;
-
-      let duplicate = false;
-      setTextRoomsByAzit((prev) => {
-        const currentRooms = prev[currentAzitId] ?? [];
-        if (currentRooms.includes(trimmed)) {
-          duplicate = true;
-          return prev;
-        }
-        const updatedRooms = currentRooms.map((room) =>
-          room === roomName ? trimmed : room
-        );
-        return { ...prev, [currentAzitId]: updatedRooms };
-      });
-      if (duplicate) return;
-
-      setMessagesByAzit((prev) => {
-        const currentAzitMessages = prev[currentAzitId] ?? {};
-        if (currentAzitMessages[trimmed]) return prev;
-        const { [roomName]: roomMessages, ...rest } = currentAzitMessages;
-        return {
-          ...prev,
-          [currentAzitId]: {
-            ...rest,
-            [trimmed]: roomMessages ?? [],
-          },
-        };
-      });
-
-      setSelectedChatRoomByAzit((prev) =>
-        prev[currentAzitId] === roomName
-          ? { ...prev, [currentAzitId]: trimmed }
-          : prev
-      );
-    },
-    [currentAzitId]
-  );
-
-  const deleteChatRoom = React.useCallback(
-    (roomName: string) => {
-      setTextRoomsByAzit((prev) => {
-        const currentRooms = prev[currentAzitId] ?? [];
-        if (currentRooms.length <= 1) return prev;
-        const nextRooms = currentRooms.filter((room) => room !== roomName);
-        return { ...prev, [currentAzitId]: nextRooms };
-      });
-
-      setMessagesByAzit((prev) => {
-        const currentAzitMessages = prev[currentAzitId] ?? {};
-        const { [roomName]: _removed, ...rest } = currentAzitMessages;
-        return {
-          ...prev,
-          [currentAzitId]: Object.keys(rest).length > 0 ? rest : { "자유 대화": [] },
-        };
-      });
-
-      setSelectedChatRoomByAzit((prev) => {
-        if (prev[currentAzitId] !== roomName) return prev;
-        const rooms = textRoomsByAzit[currentAzitId] ?? [];
-        const nextRooms = rooms.filter((room) => room !== roomName);
-        const fallback = nextRooms[0] ?? "자유 대화";
-        return { ...prev, [currentAzitId]: fallback };
-      });
-    },
-    [currentAzitId, textRoomsByAzit]
-  );
-
   const addChatMessage = React.useCallback(
     (roomName: string, content: string, files: File[]) => {
       const text = content.trim();
       if (!text && files.length === 0) return;
 
-      const media = files.map((file) => ({
-        url: URL.createObjectURL(file),
-        type: file.type.startsWith("video/") ? ("video" as const) : ("image" as const),
-      }));
+      const media = createMediaItems(files);
 
-      if (media.length > 0) {
-        messageMediaRef.current.push(...media.map((item) => item.url));
-      }
-
-      const newMessage: ChatMessage = {
-        id: `${Date.now()}`,
-        author: currentUser.nickname,
-        content: text,
-        createdAt: "방금 전",
-        media: media.length > 0 ? media : undefined,
-      };
-
-      setMessagesByAzit((prev) => {
-        const currentAzitMessages = prev[currentAzitId] ?? {};
-        const roomMessages = currentAzitMessages[roomName] ?? [];
-        return {
-          ...prev,
-          [currentAzitId]: {
-            ...currentAzitMessages,
-            [roomName]: [newMessage, ...roomMessages],
-          },
-        };
-      });
-
-      if (media.length > 0) {
-        const nowLabel = "방금 전";
-        const newClips: Clip[] = media.map((item, index) => ({
-          id: `${Date.now()}-${index}`,
-          date: nowLabel,
-          thumbnailUrl: item.type === "image" ? item.url : "",
-          mediaType: item.type,
-          mediaUrl: item.url,
-          durationLabel: item.type === "video" ? "0:00" : undefined,
-        }));
-
-        setClipsByAzit((prev) => {
-          const current = prev[currentAzitId] ?? [];
-          return {
-            ...prev,
-            [currentAzitId]: [...newClips, ...current],
-          };
-        });
-
-        newClips.forEach((clip) => {
-          if (clip.mediaType !== "video" || !clip.mediaUrl) return;
-          const video = document.createElement("video");
-          video.preload = "metadata";
-          video.src = clip.mediaUrl;
-          video.onloadedmetadata = () => {
-            const label = formatDuration(video.duration);
-            setClipsByAzit((prev) => {
-              const current = prev[currentAzitId] ?? [];
-              return {
-                ...prev,
-                [currentAzitId]: current.map((item) =>
-                  item.id === clip.id ? { ...item, durationLabel: label } : item
-                ),
-              };
-            });
-          };
-        });
-      }
+      addRoomMessage(roomName, text, media);
+      addClipsFromMedia(currentAzitId, media);
     },
-    [currentAzitId, currentUser.nickname]
+    [addClipsFromMedia, addRoomMessage, createMediaItems, currentAzitId]
   );
+
 
   React.useEffect(() => {
     return () => {
-      messageMediaRef.current.forEach((url) => URL.revokeObjectURL(url));
-      messageMediaRef.current = [];
       azitIconUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
       azitIconUrlsRef.current = [];
     };
   }, []);
-
-  const joinVoiceRoom = React.useCallback(
-    (roomId: string) => {
-      const me = currentUser;
-      setVoiceRoomsByAzit((prev) => {
-        const currentRooms = prev[currentAzitId] ?? [];
-        const hadMeInTarget = currentRooms.some(
-          (room) =>
-            room.id === roomId &&
-            room.users.some((user) => String(user.id) === String(me.id))
-        );
-
-        const nextState: Record<number, { id: string; name: string; users: User[] }[]> = {};
-
-        Object.entries(prev).forEach(([azitKey, rooms]) => {
-          nextState[Number(azitKey)] = rooms.map((room) => ({
-            ...room,
-            users: room.users.filter((user) => String(user.id) !== String(me.id)),
-          }));
-        });
-
-        if (!hadMeInTarget) {
-          const targetRooms = nextState[currentAzitId] ?? createDefaultVoiceRooms();
-          nextState[currentAzitId] = targetRooms.map((room) =>
-            room.id === roomId ? { ...room, users: [...room.users, me] } : room
-          );
-        }
-
-        return nextState;
-      });
-    },
-    [currentAzitId, currentUser]
-  );
 
   const addAzit = React.useCallback(
     (name: string, iconUrl?: string) => {
@@ -375,17 +119,11 @@ export function useAzitPageLogic() {
         icon: iconUrl ?? "",
       };
       setAzits((prev) => [...prev, nextAzit]);
-      setSelectedChatRoomByAzit((prev) => ({ ...prev, [nextId]: "자유 대화" }));
-      setTextRoomsByAzit((prev) => ({ ...prev, [nextId]: createDefaultTextRooms() }));
-      setMessagesByAzit((prev) => ({
-        ...prev,
-        [nextId]: { "자유 대화": [] },
-      }));
-      setVoiceRoomsByAzit((prev) => ({ ...prev, [nextId]: createDefaultVoiceRooms() }));
-      setClipsByAzit((prev) => ({ ...prev, [nextId]: [] }));
+      initAzitRooms(nextId);
+      initAzitClips(nextId);
       setCurrentAzitId(nextId);
     },
-    [azits, setCurrentAzitId]
+    [azits, initAzitClips, initAzitRooms, setCurrentAzitId]
   );
 
   return {
@@ -403,6 +141,7 @@ export function useAzitPageLogic() {
       schedules,
       currentUserId,
       currentUser,
+      feedbackModal,
     },
     actions: {
       setCurrentAzitId,
@@ -418,6 +157,10 @@ export function useAzitPageLogic() {
       deleteChatRoom,
       addChatMessage,
       addAzit,
+      openFeedbackModal,
+      closeFeedbackModal,
+      submitFeedback,
+      getPendingFeedbacks,
     },
   };
 }

--- a/Playproof/src/features/team/hooks/useAzitRooms.ts
+++ b/Playproof/src/features/team/hooks/useAzitRooms.ts
@@ -1,0 +1,281 @@
+import React from "react";
+import type { User } from "@/features/team/types/types";
+
+type ChatMessage = {
+  id: string;
+  author: string;
+  content: string;
+  createdAt: string;
+  media?: { url: string; type: "image" | "video" }[];
+};
+
+const createDefaultVoiceRooms = () => [
+  { id: "voice-lobby", name: "로비", users: [] as User[] },
+];
+
+const createDefaultTextRooms = () => ["자유 대화"];
+
+export const useAzitRooms = (currentAzitId: number, currentUser: User) => {
+  const [selectedChatRoomByAzit, setSelectedChatRoomByAzit] = React.useState<
+    Record<number, string>
+  >({
+    1: "자유 대화",
+    2: "자유 대화",
+    3: "자유 대화",
+  });
+  const [textRoomsByAzit, setTextRoomsByAzit] = React.useState<Record<number, string[]>>({
+    1: createDefaultTextRooms(),
+    2: createDefaultTextRooms(),
+    3: createDefaultTextRooms(),
+  });
+  const [messagesByAzit, setMessagesByAzit] = React.useState<
+    Record<number, Record<string, ChatMessage[]>>
+  >({
+    1: { "자유 대화": [] },
+    2: { "자유 대화": [] },
+    3: { "자유 대화": [] },
+  });
+  const [voiceRoomsByAzit, setVoiceRoomsByAzit] = React.useState<
+    Record<number, { id: string; name: string; users: User[] }[]>
+  >({
+    1: createDefaultVoiceRooms(),
+    2: createDefaultVoiceRooms(),
+    3: createDefaultVoiceRooms(),
+  });
+
+  const selectedChatRoom = selectedChatRoomByAzit[currentAzitId] ?? "자유 대화";
+  const voiceRooms = voiceRoomsByAzit[currentAzitId] ?? createDefaultVoiceRooms();
+  const textRooms = textRoomsByAzit[currentAzitId] ?? createDefaultTextRooms();
+  const messages = messagesByAzit[currentAzitId]?.[selectedChatRoom] ?? [];
+
+  const setSelectedChatRoom = React.useCallback(
+    (roomName: string) => {
+      setSelectedChatRoomByAzit((prev) => ({ ...prev, [currentAzitId]: roomName }));
+    },
+    [currentAzitId]
+  );
+
+  const addChatRoom = React.useCallback(
+    (name: string, type: "TEXT" | "VOICE") => {
+      if (!name.trim()) return;
+      if (type === "TEXT") {
+        setTextRoomsByAzit((prev) => {
+          const currentRooms = prev[currentAzitId] ?? [];
+          if (currentRooms.includes(name)) return prev;
+          return { ...prev, [currentAzitId]: [name, ...currentRooms] };
+        });
+        setMessagesByAzit((prev) => {
+          const currentAzitMessages = prev[currentAzitId] ?? {};
+          if (currentAzitMessages[name]) return prev;
+          return {
+            ...prev,
+            [currentAzitId]: { ...currentAzitMessages, [name]: [] },
+          };
+        });
+        setSelectedChatRoomByAzit((prev) => ({ ...prev, [currentAzitId]: name }));
+        return;
+      }
+
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
+        if (currentRooms.some((room) => room.name === name)) return prev;
+        const nextRooms = [
+          { id: `voice-${Date.now()}`, name, users: [] as User[] },
+          ...currentRooms,
+        ];
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+    },
+    [currentAzitId]
+  );
+
+  const renameVoiceRoom = React.useCallback(
+    (roomId: string, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed) return;
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
+        if (currentRooms.some((room) => room.name === trimmed)) {
+          return prev;
+        }
+        const nextRooms = currentRooms.map((room) =>
+          room.id === roomId ? { ...room, name: trimmed } : room
+        );
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+    },
+    [currentAzitId]
+  );
+
+  const deleteVoiceRoom = React.useCallback(
+    (roomId: string) => {
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
+        if (currentRooms.length <= 1) return prev;
+        const nextRooms = currentRooms.filter((room) => room.id !== roomId);
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+    },
+    [currentAzitId]
+  );
+
+  const renameChatRoom = React.useCallback(
+    (roomName: string, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed || trimmed === roomName) return;
+
+      let duplicate = false;
+      setTextRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? [];
+        if (currentRooms.includes(trimmed)) {
+          duplicate = true;
+          return prev;
+        }
+        const updatedRooms = currentRooms.map((room) =>
+          room === roomName ? trimmed : room
+        );
+        return { ...prev, [currentAzitId]: updatedRooms };
+      });
+      if (duplicate) return;
+
+      setMessagesByAzit((prev) => {
+        const currentAzitMessages = prev[currentAzitId] ?? {};
+        if (currentAzitMessages[trimmed]) return prev;
+        const { [roomName]: roomMessages, ...rest } = currentAzitMessages;
+        return {
+          ...prev,
+          [currentAzitId]: {
+            ...rest,
+            [trimmed]: roomMessages ?? [],
+          },
+        };
+      });
+
+      setSelectedChatRoomByAzit((prev) =>
+        prev[currentAzitId] === roomName
+          ? { ...prev, [currentAzitId]: trimmed }
+          : prev
+      );
+    },
+    [currentAzitId]
+  );
+
+  const deleteChatRoom = React.useCallback(
+    (roomName: string) => {
+      setTextRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? [];
+        if (currentRooms.length <= 1) return prev;
+        const nextRooms = currentRooms.filter((room) => room !== roomName);
+        return { ...prev, [currentAzitId]: nextRooms };
+      });
+
+      setMessagesByAzit((prev) => {
+        const currentAzitMessages = prev[currentAzitId] ?? {};
+        const nextMessages = { ...currentAzitMessages };
+        delete nextMessages[roomName];
+        return {
+          ...prev,
+          [currentAzitId]:
+            Object.keys(nextMessages).length > 0 ? nextMessages : { "자유 대화": [] },
+        };
+      });
+
+      setSelectedChatRoomByAzit((prev) => {
+        if (prev[currentAzitId] !== roomName) return prev;
+        const rooms = textRoomsByAzit[currentAzitId] ?? [];
+        const nextRooms = rooms.filter((room) => room !== roomName);
+        const fallback = nextRooms[0] ?? "자유 대화";
+        return { ...prev, [currentAzitId]: fallback };
+      });
+    },
+    [currentAzitId, textRoomsByAzit]
+  );
+
+  const addChatMessage = React.useCallback(
+    (
+      roomName: string,
+      content: string,
+      media: { url: string; type: "image" | "video" }[]
+    ) => {
+      const text = content.trim();
+      if (!text && media.length === 0) return;
+
+      const newMessage: ChatMessage = {
+        id: `${Date.now()}`,
+        author: currentUser.nickname,
+        content: text,
+        createdAt: "방금 전",
+        media: media.length > 0 ? media : undefined,
+      };
+
+      setMessagesByAzit((prev) => {
+        const currentAzitMessages = prev[currentAzitId] ?? {};
+        const roomMessages = currentAzitMessages[roomName] ?? [];
+        return {
+          ...prev,
+          [currentAzitId]: {
+            ...currentAzitMessages,
+            [roomName]: [newMessage, ...roomMessages],
+          },
+        };
+      });
+    },
+    [currentAzitId, currentUser.nickname]
+  );
+
+  const joinVoiceRoom = React.useCallback(
+    (roomId: string) => {
+      const me = currentUser;
+      setVoiceRoomsByAzit((prev) => {
+        const currentRooms = prev[currentAzitId] ?? [];
+        const hadMeInTarget = currentRooms.some(
+          (room) =>
+            room.id === roomId &&
+            room.users.some((user) => String(user.id) === String(me.id))
+        );
+
+        const nextState: Record<number, { id: string; name: string; users: User[] }[]> = {};
+
+        Object.entries(prev).forEach(([azitKey, rooms]) => {
+          nextState[Number(azitKey)] = rooms.map((room) => ({
+            ...room,
+            users: room.users.filter((user) => String(user.id) !== String(me.id)),
+          }));
+        });
+
+        if (!hadMeInTarget) {
+          const targetRooms = nextState[currentAzitId] ?? createDefaultVoiceRooms();
+          nextState[currentAzitId] = targetRooms.map((room) =>
+            room.id === roomId ? { ...room, users: [...room.users, me] } : room
+          );
+        }
+
+        return nextState;
+      });
+    },
+    [currentAzitId, currentUser]
+  );
+
+  const initAzitRooms = React.useCallback((azitId: number) => {
+    setSelectedChatRoomByAzit((prev) => ({ ...prev, [azitId]: "자유 대화" }));
+    setTextRoomsByAzit((prev) => ({ ...prev, [azitId]: createDefaultTextRooms() }));
+    setMessagesByAzit((prev) => ({ ...prev, [azitId]: { "자유 대화": [] } }));
+    setVoiceRoomsByAzit((prev) => ({ ...prev, [azitId]: createDefaultVoiceRooms() }));
+  }, []);
+
+  return {
+    selectedChatRoom,
+    voiceRooms,
+    textRooms,
+    messages,
+    setSelectedChatRoom,
+    addChatRoom,
+    renameVoiceRoom,
+    deleteVoiceRoom,
+    renameChatRoom,
+    deleteChatRoom,
+    addChatMessage,
+    joinVoiceRoom,
+    initAzitRooms,
+  };
+};

--- a/Playproof/src/features/team/hooks/useAzitSchedules.ts
+++ b/Playproof/src/features/team/hooks/useAzitSchedules.ts
@@ -1,12 +1,26 @@
 import React from "react";
 import type { Schedule, User } from "@/features/team/types/types";
 
+type TimeSelection = {
+  ampm: "AM" | "PM";
+  hour: number;
+  minute: number;
+};
+
+type CreateSchedulePayload = {
+  title: string;
+  recruitCount: number;
+  gameDate?: Date;
+  gameStartTime: TimeSelection;
+};
+
 const coerceUserId = (value: string | number) => String(value);
 
 export function useAzitSchedules(
   currentUserId: string,
   schedulesByAzit: Record<number, Schedule[]>,
-  membersByAzit: Record<number, User[]>
+  membersByAzit: Record<number, User[]>,
+  currentUser: User
 ) {
   const [currentAzitId, setCurrentAzitId] = React.useState<number>(1);
   const [schedules, setSchedules] = React.useState<Schedule[]>([]);
@@ -50,11 +64,45 @@ export function useAzitSchedules(
     [currentUserId, currentAzitId, membersByAzit]
   );
 
+  const addSchedule = React.useCallback(
+    (data: CreateSchedulePayload) => {
+      if (!data.gameDate) return;
+      const date = new Date(data.gameDate);
+      const hour = data.gameStartTime.hour % 12 + (data.gameStartTime.ampm === "PM" ? 12 : 0);
+      date.setHours(hour, data.gameStartTime.minute, 0, 0);
+
+      const timeStr = date.toLocaleTimeString("ko-KR", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
+      const dateStr = `${String(date.getMonth() + 1).padStart(2, "0")}.${String(
+        date.getDate()
+      ).padStart(2, "0")}`;
+
+      const newSchedule: Schedule = {
+        id: String(Date.now()),
+        title: data.title.trim(),
+        dateStr,
+        timeStr,
+        fullDate: date,
+        hostId: String(currentUserId),
+        maxMembers: data.recruitCount,
+        participants: [{ user: currentUser, status: "JOIN" }],
+        isFeedbackDone: false,
+      };
+
+      setSchedules((prev) => [newSchedule, ...prev]);
+    },
+    [currentUser, currentUserId]
+  );
+
   return {
     currentAzitId,
     setCurrentAzitId,
     schedules,
     setSchedules,
     handleStatusChange,
+    addSchedule,
   };
 }

--- a/Playproof/src/features/team/hooks/useAzitSchedules.ts
+++ b/Playproof/src/features/team/hooks/useAzitSchedules.ts
@@ -1,0 +1,60 @@
+import React from "react";
+import type { Schedule, User } from "@/features/team/types/types";
+
+const coerceUserId = (value: string | number) => String(value);
+
+export function useAzitSchedules(
+  currentUserId: string,
+  schedulesByAzit: Record<number, Schedule[]>,
+  membersByAzit: Record<number, User[]>
+) {
+  const [currentAzitId, setCurrentAzitId] = React.useState<number>(1);
+  const [schedules, setSchedules] = React.useState<Schedule[]>([]);
+
+  React.useEffect(() => {
+    const initialSchedules = schedulesByAzit[currentAzitId] ?? [];
+    setSchedules(initialSchedules);
+  }, [currentAzitId, schedulesByAzit]);
+
+  const handleStatusChange = React.useCallback(
+    (scheduleId: string, newStatus: "JOIN" | "DECLINE") => {
+      setSchedules((prevSchedules) =>
+        prevSchedules.map((sch) => {
+          if (sch.id !== scheduleId) return sch;
+
+          const myIndex = sch.participants.findIndex(
+            (p) => coerceUserId(p.user?.id ?? "") === coerceUserId(currentUserId)
+          );
+
+          const nextParticipants = [...sch.participants];
+
+          if (myIndex !== -1) {
+            nextParticipants[myIndex] = {
+              ...nextParticipants[myIndex],
+              status: newStatus,
+            };
+          } else {
+            const members = membersByAzit[currentAzitId] ?? [];
+            const me = members.find(
+              (member) => coerceUserId(member.id) === coerceUserId(currentUserId)
+            );
+            if (me) {
+              nextParticipants.push({ user: me, status: newStatus });
+            }
+          }
+
+          return { ...sch, participants: nextParticipants };
+        })
+      );
+    },
+    [currentUserId, currentAzitId, membersByAzit]
+  );
+
+  return {
+    currentAzitId,
+    setCurrentAzitId,
+    schedules,
+    setSchedules,
+    handleStatusChange,
+  };
+}

--- a/Playproof/src/features/team/hooks/useAzitSchedules.ts
+++ b/Playproof/src/features/team/hooks/useAzitSchedules.ts
@@ -97,6 +97,12 @@ export function useAzitSchedules(
     [currentUser, currentUserId]
   );
 
+  const markFeedbackDone = React.useCallback((scheduleId: string) => {
+    setSchedules((prev) =>
+      prev.map((sch) => (sch.id === scheduleId ? { ...sch, isFeedbackDone: true } : sch))
+    );
+  }, []);
+
   return {
     currentAzitId,
     setCurrentAzitId,
@@ -104,5 +110,6 @@ export function useAzitSchedules(
     setSchedules,
     handleStatusChange,
     addSchedule,
+    markFeedbackDone,
   };
 }

--- a/Playproof/src/features/team/hooks/useScheduleCreateState.ts
+++ b/Playproof/src/features/team/hooks/useScheduleCreateState.ts
@@ -1,0 +1,152 @@
+import React from "react";
+import type { DateRange } from "react-day-picker";
+
+interface TimeSelection {
+  ampm: "AM" | "PM";
+  hour: number;
+  minute: number;
+}
+
+type UseScheduleCreateStateArgs = {
+  anchorEl: HTMLElement | null;
+  onCreate: (data: any) => void;
+  onClose: () => void;
+};
+
+export function useScheduleCreateState({
+  anchorEl,
+  onCreate,
+  onClose,
+}: UseScheduleCreateStateArgs) {
+  const [position, setPosition] = React.useState({ top: 0, left: 0 });
+  const [title, setTitle] = React.useState("");
+  const [recruitCount, setRecruitCount] = React.useState(0);
+  const [gameDate, setGameDate] = React.useState<Date | undefined>(undefined);
+  const [isGameDateOpen, setIsGameDateOpen] = React.useState(false);
+  const [gameStartTime, setGameStartTime] = React.useState<TimeSelection>({
+    ampm: "AM",
+    hour: 12,
+    minute: 0,
+  });
+  const [gameEndTime, setGameEndTime] = React.useState<TimeSelection>({
+    ampm: "AM",
+    hour: 12,
+    minute: 0,
+  });
+  const [recruitRange, setRecruitRange] = React.useState<DateRange | undefined>(undefined);
+  const [isRecruitDateOpen, setIsRecruitDateOpen] = React.useState(false);
+  const [recruitStartTime, setRecruitStartTime] = React.useState<TimeSelection>({
+    ampm: "AM",
+    hour: 12,
+    minute: 0,
+  });
+  const [recruitEndTime, setRecruitEndTime] = React.useState<TimeSelection>({
+    ampm: "AM",
+    hour: 12,
+    minute: 0,
+  });
+  const [activeTimePicker, setActiveTimePicker] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!anchorEl) return;
+    const rect = anchorEl.getBoundingClientRect();
+    setPosition({
+      top: rect.bottom + window.scrollY + 8,
+      left: rect.left + window.scrollX,
+    });
+  }, [anchorEl]);
+
+  const handleRecruitCount = (delta: number) => {
+    setRecruitCount((prev) => Math.max(0, prev + delta));
+  };
+
+  const formatDate = (date: Date | undefined) =>
+    date
+      ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+          date.getDate()
+        ).padStart(2, "0")}`
+      : "날짜를 선택해주세요.";
+
+  const formatRange = (range: DateRange | undefined) =>
+    range?.from
+      ? `${formatDate(range.from)} ~ ${range.to ? formatDate(range.to) : formatDate(range.from)}`
+      : "날짜를 선택해주세요.";
+
+  const validateForm = () => {
+    if (!title.trim()) return { isValid: false, msg: "제목을 입력해주세요." };
+    if (!gameDate) return { isValid: false, msg: "게임 일정을 선택해주세요." };
+    if (!recruitRange?.from) return { isValid: false, msg: "모집 기간을 선택해주세요." };
+
+    const game = new Date(gameDate);
+    game.setHours(0, 0, 0, 0);
+
+    const recruitStart = new Date(recruitRange.from);
+    recruitStart.setHours(0, 0, 0, 0);
+
+    if (recruitStart > game) {
+      return { isValid: false, msg: "모집 기간이 게임 일정보다 늦습니다." };
+    }
+
+    if (recruitRange.to) {
+      const recruitEnd = new Date(recruitRange.to);
+      recruitEnd.setHours(0, 0, 0, 0);
+      if (recruitEnd > game) {
+        return { isValid: false, msg: "모집 종료일은 게임 일정 이전이어야 합니다." };
+      }
+    }
+
+    return { isValid: true, msg: "" };
+  };
+
+  const { isValid, msg } = validateForm();
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    onCreate({
+      title,
+      recruitCount,
+      gameDate,
+      gameStartTime,
+      gameEndTime,
+      recruitRange,
+      recruitStartTime,
+      recruitEndTime,
+    });
+    onClose();
+  };
+
+  return {
+    state: {
+      position,
+      title,
+      recruitCount,
+      gameDate,
+      isGameDateOpen,
+      gameStartTime,
+      gameEndTime,
+      recruitRange,
+      isRecruitDateOpen,
+      recruitStartTime,
+      recruitEndTime,
+      activeTimePicker,
+      isValid,
+      msg,
+    },
+    actions: {
+      setTitle,
+      setGameDate,
+      setIsGameDateOpen,
+      setGameStartTime,
+      setGameEndTime,
+      setRecruitRange,
+      setIsRecruitDateOpen,
+      setRecruitStartTime,
+      setRecruitEndTime,
+      setActiveTimePicker,
+      handleRecruitCount,
+      handleSubmit,
+      formatDate,
+      formatRange,
+    },
+  };
+}

--- a/Playproof/src/features/team/hooks/useScheduleCreateState.ts
+++ b/Playproof/src/features/team/hooks/useScheduleCreateState.ts
@@ -1,15 +1,26 @@
 import React from "react";
 import type { DateRange } from "react-day-picker";
 
-interface TimeSelection {
+export interface TimeSelection {
   ampm: "AM" | "PM";
   hour: number;
   minute: number;
 }
 
+export type ScheduleCreatePayload = {
+  title: string;
+  recruitCount: number;
+  gameDate?: Date;
+  gameStartTime: TimeSelection;
+  gameEndTime: TimeSelection;
+  recruitRange?: DateRange;
+  recruitStartTime: TimeSelection;
+  recruitEndTime: TimeSelection;
+};
+
 type UseScheduleCreateStateArgs = {
   anchorEl: HTMLElement | null;
-  onCreate: (data: any) => void;
+  onCreate: (data: ScheduleCreatePayload) => void;
   onClose: () => void;
 };
 
@@ -18,7 +29,14 @@ export function useScheduleCreateState({
   onCreate,
   onClose,
 }: UseScheduleCreateStateArgs) {
-  const [position, setPosition] = React.useState({ top: 0, left: 0 });
+  const position = React.useMemo(() => {
+    if (!anchorEl) return { top: 0, left: 0 };
+    const rect = anchorEl.getBoundingClientRect();
+    return {
+      top: rect.bottom + window.scrollY + 8,
+      left: rect.left + window.scrollX,
+    };
+  }, [anchorEl]);
   const [title, setTitle] = React.useState("");
   const [recruitCount, setRecruitCount] = React.useState(0);
   const [gameDate, setGameDate] = React.useState<Date | undefined>(undefined);
@@ -46,15 +64,6 @@ export function useScheduleCreateState({
     minute: 0,
   });
   const [activeTimePicker, setActiveTimePicker] = React.useState<string | null>(null);
-
-  React.useEffect(() => {
-    if (!anchorEl) return;
-    const rect = anchorEl.getBoundingClientRect();
-    setPosition({
-      top: rect.bottom + window.scrollY + 8,
-      left: rect.left + window.scrollX,
-    });
-  }, [anchorEl]);
 
   const handleRecruitCount = (delta: number) => {
     setRecruitCount((prev) => Math.max(0, prev + delta));
@@ -102,7 +111,7 @@ export function useScheduleCreateState({
 
   const handleSubmit = () => {
     if (!isValid) return;
-    onCreate({
+    const payload: ScheduleCreatePayload = {
       title,
       recruitCount,
       gameDate,
@@ -111,7 +120,8 @@ export function useScheduleCreateState({
       recruitRange,
       recruitStartTime,
       recruitEndTime,
-    });
+    };
+    onCreate(payload);
     onClose();
   };
 

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -1,5 +1,6 @@
 // src/features/team/pages/AzitPageView.tsx
 import React from 'react';
+import { useNavigate } from "react-router-dom";
 import { Settings, Users } from 'lucide-react';
 import { Navbar } from '@/components/common/Navbar';
 
@@ -8,23 +9,31 @@ import { LeftPanel } from '@/features/team/components/azit/LeftPanel';
 import { MainPanel } from '@/features/team/components/azit/MainPanel';
 import { RightPanel } from '@/features/team/components/azit/RightPanel';
 import { ScheduleCreateModal } from '@/features/team/components/schedule/ScheduleCreateModal';
+import { AzitCreateModal } from '@/features/team/components/azit/AzitCreateModal';
 
 import { useAzitPageLogic } from '@/features/team/hooks/useAzitPageLogic';
 
 export const AzitPageView = () => {
+  const navigate = useNavigate();
   const { state, actions } = useAzitPageLogic();
+  const [isAzitCreateOpen, setIsAzitCreateOpen] = React.useState(false);
   const {
     currentAzitId,
     scheduleAnchorEl,
+    selectedChatRoom,
+    voiceRooms,
+    textRooms,
+    messages,
     currentAzit,
     currentMembers,
     currentClips,
     schedules,
     currentUserId,
+    currentUser,
   } = state;
 
   const handleCreateSchedule = (data: any) => {
-    console.log("새 스케줄 데이터:", data);
+    actions.addSchedule(data);
   };
 
   return (
@@ -40,6 +49,7 @@ export const AzitPageView = () => {
             azits={state.azits}
             selectedId={currentAzitId} 
             onSelect={actions.setCurrentAzitId}
+            onOpenCreate={() => setIsAzitCreateOpen(true)}
           />
         </div>
 
@@ -67,14 +77,35 @@ export const AzitPageView = () => {
             currentUserId={currentUserId}
             onAddSchedule={(target) => actions.setScheduleAnchorEl(target)}
             onStatusChange={actions.handleStatusChange} // 핸들러 전달
+            selectedChatRoom={selectedChatRoom}
+            onSelectChatRoom={actions.setSelectedChatRoom}
+            voiceRooms={voiceRooms}
+            onJoinVoiceRoom={(roomId) => actions.joinVoiceRoom(roomId)}
+            textRooms={textRooms}
+            onCreateChatRoom={actions.addChatRoom}
+            onRenameVoiceRoom={actions.renameVoiceRoom}
+            onDeleteVoiceRoom={actions.deleteVoiceRoom}
+            onRenameChatRoom={actions.renameChatRoom}
+            onDeleteChatRoom={actions.deleteChatRoom}
           />
           
-          <MainPanel key={currentAzitId} />
+          <MainPanel
+            key={currentAzitId}
+            roomName={selectedChatRoom}
+            messages={messages}
+            onSendMessage={actions.addChatMessage}
+            currentUserName={currentUser.nickname}
+          />
           
           <div className="w-[300px] flex flex-col shrink-0 gap-4">
              <div className="flex justify-between items-center px-1">
                <h2 className="text-lg font-bold text-gray-900">하이라이트</h2>
-               <button className="text-xs text-gray-500 underline font-medium">전체보기</button>
+               <button
+                 className="text-xs text-gray-500 underline font-medium"
+                 onClick={() => navigate("/community?tab=하이라이트")}
+               >
+                 전체보기
+               </button>
              </div>
              <RightPanel clips={currentClips} />
           </div>
@@ -85,6 +116,15 @@ export const AzitPageView = () => {
         anchorEl={scheduleAnchorEl}
         onClose={() => actions.setScheduleAnchorEl(null)}
         onCreate={handleCreateSchedule}
+      />
+
+      <AzitCreateModal
+        open={isAzitCreateOpen}
+        onClose={() => setIsAzitCreateOpen(false)}
+        onCreate={({ name, iconUrl }) => {
+          actions.addAzit(name, iconUrl);
+          setIsAzitCreateOpen(false);
+        }}
       />
     </div>
   );

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -1,6 +1,5 @@
 // src/features/team/pages/AzitPageView.tsx
-import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import React from 'react';
 import { Settings, Users } from 'lucide-react';
 import { Navbar } from '@/components/common/Navbar';
 
@@ -10,29 +9,22 @@ import { MainPanel } from '@/features/team/components/azit/MainPanel';
 import { RightPanel } from '@/features/team/components/azit/RightPanel';
 import { ScheduleCreateModal } from '@/features/team/components/schedule/ScheduleCreateModal';
 
-import {
-  MOCK_MY_AZITS,
-  mockClipsByAzit,
-  mockMembersByAzit,
-  mockSchedulesByAzit,
-} from '@/features/team/data/mockTeamData';
+import { useAzitPageLogic } from '@/features/team/hooks/useAzitPageLogic';
 
 export const AzitPageView = () => {
-  const location = useLocation();
-  const state = location.state as { azitId?: number } | null;
-  const [currentAzitId, setCurrentAzitId] = useState<number>(state?.azitId ?? 1);
-  
-  // 모달 위치의 기준이 될 요소(Anchor Element)
-  const [scheduleAnchorEl, setScheduleAnchorEl] = useState<HTMLElement | null>(null);
-
-  const currentAzit = MOCK_MY_AZITS.find(a => a.id === currentAzitId) || MOCK_MY_AZITS[0];
-  const currentMembers = mockMembersByAzit[currentAzitId] ?? mockMembersByAzit[1];
-  const currentClips = mockClipsByAzit[currentAzitId] ?? mockClipsByAzit[1];
-  const currentSchedules = mockSchedulesByAzit[currentAzitId] ?? mockSchedulesByAzit[1];
+  const { state, actions } = useAzitPageLogic();
+  const {
+    currentAzitId,
+    scheduleAnchorEl,
+    currentAzit,
+    currentMembers,
+    currentClips,
+    schedules,
+    currentUserId,
+  } = state;
 
   const handleCreateSchedule = (data: any) => {
     console.log("새 스케줄 데이터:", data);
-    // TODO: 백엔드 API 전송 로직
   };
 
   return (
@@ -45,9 +37,9 @@ export const AzitPageView = () => {
         {/* Navigation */}
         <div className="flex-none">
           <AzitNavigation 
-            azits={MOCK_MY_AZITS} 
+            azits={state.azits}
             selectedId={currentAzitId} 
-            onSelect={setCurrentAzitId}
+            onSelect={actions.setCurrentAzitId}
           />
         </div>
 
@@ -69,11 +61,12 @@ export const AzitPageView = () => {
 
         {/* Content Layout */}
         <div className="flex flex-1 px-6 pb-6 gap-8 overflow-hidden">
-          {/* ✅ LeftPanel에서 넘겨준 요소(헤더 div)를 상태에 저장 */}
           <LeftPanel 
             members={currentMembers} 
-            schedules={currentSchedules} 
-            onAddSchedule={(target) => setScheduleAnchorEl(target)}
+            schedules={schedules}  // State 전달
+            currentUserId={currentUserId}
+            onAddSchedule={(target) => actions.setScheduleAnchorEl(target)}
+            onStatusChange={actions.handleStatusChange} // 핸들러 전달
           />
           
           <MainPanel key={currentAzitId} />
@@ -88,10 +81,9 @@ export const AzitPageView = () => {
         </div>
       </div>
 
-      {/* Anchor Element가 있으면 모달을 렌더링하고, 위치를 해당 요소 기준으로 잡음 */}
       <ScheduleCreateModal 
         anchorEl={scheduleAnchorEl}
-        onClose={() => setScheduleAnchorEl(null)}
+        onClose={() => actions.setScheduleAnchorEl(null)}
         onCreate={handleCreateSchedule}
       />
     </div>

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -56,7 +56,7 @@ export const AzitPageView = () => {
         <Navbar />
       </div>
 
-      <div className="flex flex-col flex-1 overflow-hidden w-full max-w-[1920px] mx-auto">
+      <div className="flex flex-col flex-1 overflow-y-auto lg:overflow-hidden w-full max-w-[1920px] mx-auto">
         {/* Navigation */}
         <div className="flex-none">
           <AzitNavigation 
@@ -68,8 +68,8 @@ export const AzitPageView = () => {
         </div>
 
         {/* Header */}
-        <div className="px-6 pb-2 pt-2 shrink-0">
-          <div className="h-[60px] bg-gray-100 rounded-xl flex items-center justify-between px-6">
+        <div className="px-4 sm:px-6 pb-2 pt-2 shrink-0">
+          <div className="min-h-[60px] bg-gray-100 rounded-xl flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between px-4 sm:px-6 py-3 sm:py-0">
             <div className="flex items-center gap-3">
               <button
                 onClick={handleBackClick}
@@ -84,14 +84,14 @@ export const AzitPageView = () => {
                 <span className="text-sm">{currentAzit.memberCount}</span>
               </div>
             </div>
-            <button className="text-gray-400 hover:bg-gray-200 rounded-full p-2 transition-colors">
+            <button className="text-gray-400 hover:bg-gray-200 rounded-full p-2 transition-colors self-end sm:self-auto">
               <Settings className="w-5 h-5" />
             </button>
           </div>
         </div>
 
         {/* Content Layout */}
-        <div className="flex flex-1 px-6 pb-6 gap-8 overflow-hidden">
+        <div className="flex flex-1 flex-col lg:flex-row px-4 sm:px-6 pb-6 gap-6 lg:gap-8 overflow-visible lg:overflow-hidden">
           <LeftPanel 
             members={currentMembers} 
             schedules={schedules}  // State 전달
@@ -119,7 +119,7 @@ export const AzitPageView = () => {
             currentUserName={currentUser.nickname}
           />
           
-          <div className="w-[300px] flex flex-col shrink-0 gap-4">
+          <div className="w-full lg:w-[300px] flex flex-col shrink-0 gap-4">
              <div className="flex justify-between items-center px-1">
                <h2 className="text-lg font-bold text-gray-900">하이라이트</h2>
                <button

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -1,7 +1,7 @@
 // src/features/team/pages/AzitPageView.tsx
 import React from 'react';
 import { useNavigate } from "react-router-dom";
-import { Settings, Users } from 'lucide-react';
+import { ArrowLeft, Settings, Users } from 'lucide-react';
 import { Navbar } from '@/components/common/Navbar';
 
 import { AzitNavigation } from '@/features/team/components/azit/AzitNavigation';
@@ -9,7 +9,9 @@ import { LeftPanel } from '@/features/team/components/azit/LeftPanel';
 import { MainPanel } from '@/features/team/components/azit/MainPanel';
 import { RightPanel } from '@/features/team/components/azit/RightPanel';
 import { ScheduleCreateModal } from '@/features/team/components/schedule/ScheduleCreateModal';
+import type { ScheduleCreatePayload } from "@/features/team/hooks/useScheduleCreateState";
 import { AzitCreateModal } from '@/features/team/components/azit/AzitCreateModal';
+import { FeedbackModal } from "@/features/team/components/feedback/FeedbackModal";
 
 import { useAzitPageLogic } from '@/features/team/hooks/useAzitPageLogic';
 
@@ -30,10 +32,22 @@ export const AzitPageView = () => {
     schedules,
     currentUserId,
     currentUser,
+    feedbackModal,
   } = state;
 
-  const handleCreateSchedule = (data: any) => {
+  const handleCreateSchedule = (data: ScheduleCreatePayload) => {
     actions.addSchedule(data);
+  };
+
+  const handleBackClick = () => {
+    const pending = actions.getPendingFeedbacks().find(
+      (item) => item.azitId === currentAzitId
+    );
+    if (pending) {
+      actions.openFeedbackModal(pending.scheduleId, true);
+      return;
+    }
+    navigate(-1);
   };
 
   return (
@@ -57,6 +71,13 @@ export const AzitPageView = () => {
         <div className="px-6 pb-2 pt-2 shrink-0">
           <div className="h-[60px] bg-gray-100 rounded-xl flex items-center justify-between px-6">
             <div className="flex items-center gap-3">
+              <button
+                onClick={handleBackClick}
+                className="text-gray-500 hover:text-gray-900"
+                aria-label="돌아가기"
+              >
+                <ArrowLeft className="w-5 h-5" />
+              </button>
               <h1 className="text-xl font-extrabold text-gray-900 tracking-tight">{currentAzit.name}</h1>
               <div className="flex items-center gap-1 text-gray-500 font-bold mt-0.5">
                 <Users className="w-4 h-4" />
@@ -77,6 +98,7 @@ export const AzitPageView = () => {
             currentUserId={currentUserId}
             onAddSchedule={(target) => actions.setScheduleAnchorEl(target)}
             onStatusChange={actions.handleStatusChange} // 핸들러 전달
+            onFeedback={(scheduleId) => actions.openFeedbackModal(scheduleId)}
             selectedChatRoom={selectedChatRoom}
             onSelectChatRoom={actions.setSelectedChatRoom}
             voiceRooms={voiceRooms}
@@ -124,6 +146,19 @@ export const AzitPageView = () => {
         onCreate={({ name, iconUrl }) => {
           actions.addAzit(name, iconUrl);
           setIsAzitCreateOpen(false);
+        }}
+      />
+
+      <FeedbackModal
+        open={feedbackModal.open}
+        required={feedbackModal.required}
+        targetName={feedbackModal.targetName ?? "상대방"}
+        targetMeta={feedbackModal.targetMeta}
+        avatarUrl={feedbackModal.avatarUrl}
+        onClose={actions.closeFeedbackModal}
+        onSubmit={() => {
+          if (!feedbackModal.scheduleId) return;
+          actions.submitFeedback(feedbackModal.scheduleId);
         }}
       />
     </div>

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -4,11 +4,12 @@ import { useLocation } from 'react-router-dom';
 import { Settings, Users } from 'lucide-react';
 import { Navbar } from '@/components/common/Navbar';
 
-// 분리된 컴포넌트 및 데이터 import
 import { AzitNavigation } from '@/features/team/components/azit/AzitNavigation';
 import { LeftPanel } from '@/features/team/components/azit/LeftPanel';
 import { MainPanel } from '@/features/team/components/azit/MainPanel';
 import { RightPanel } from '@/features/team/components/azit/RightPanel';
+import { ScheduleCreateModal } from '@/features/team/components/schedule/ScheduleCreateModal';
+
 import {
   MOCK_MY_AZITS,
   mockClipsByAzit,
@@ -20,10 +21,19 @@ export const AzitPageView = () => {
   const location = useLocation();
   const state = location.state as { azitId?: number } | null;
   const [currentAzitId, setCurrentAzitId] = useState<number>(state?.azitId ?? 1);
+  
+  // 모달 위치의 기준이 될 요소(Anchor Element)
+  const [scheduleAnchorEl, setScheduleAnchorEl] = useState<HTMLElement | null>(null);
+
   const currentAzit = MOCK_MY_AZITS.find(a => a.id === currentAzitId) || MOCK_MY_AZITS[0];
   const currentMembers = mockMembersByAzit[currentAzitId] ?? mockMembersByAzit[1];
   const currentClips = mockClipsByAzit[currentAzitId] ?? mockClipsByAzit[1];
   const currentSchedules = mockSchedulesByAzit[currentAzitId] ?? mockSchedulesByAzit[1];
+
+  const handleCreateSchedule = (data: any) => {
+    console.log("새 스케줄 데이터:", data);
+    // TODO: 백엔드 API 전송 로직
+  };
 
   return (
     <div className="flex flex-col h-screen bg-white">
@@ -59,8 +69,13 @@ export const AzitPageView = () => {
 
         {/* Content Layout */}
         <div className="flex flex-1 px-6 pb-6 gap-8 overflow-hidden">
-          <LeftPanel members={currentMembers} schedules={currentSchedules} />
-          {/* 아지트 변경 시 채팅 상태 리셋을 위해 key prop 사용 */}
+          {/* ✅ LeftPanel에서 넘겨준 요소(헤더 div)를 상태에 저장 */}
+          <LeftPanel 
+            members={currentMembers} 
+            schedules={currentSchedules} 
+            onAddSchedule={(target) => setScheduleAnchorEl(target)}
+          />
+          
           <MainPanel key={currentAzitId} />
           
           <div className="w-[300px] flex flex-col shrink-0 gap-4">
@@ -72,6 +87,13 @@ export const AzitPageView = () => {
           </div>
         </div>
       </div>
+
+      {/* Anchor Element가 있으면 모달을 렌더링하고, 위치를 해당 요소 기준으로 잡음 */}
+      <ScheduleCreateModal 
+        anchorEl={scheduleAnchorEl}
+        onClose={() => setScheduleAnchorEl(null)}
+        onCreate={handleCreateSchedule}
+      />
     </div>
   );
 };

--- a/Playproof/src/features/team/types/types.ts
+++ b/Playproof/src/features/team/types/types.ts
@@ -30,3 +30,13 @@ export interface Clip {
   date: string;
   thumbnailUrl: string;
 }
+
+export interface CustomMatchSchedule {
+  id: string;
+  title: string;        // 유저가 직접 입력하는 제목
+  startTime: string;    // 시작 시간 (예: "20:00")
+  targetDate: Date;     // 매칭 마감 시각 (카운트다운 기준)
+  currentParticipants: number;
+  maxParticipants: number;
+  status: '모집중' | '매칭완료';
+}

--- a/Playproof/src/features/team/types/types.ts
+++ b/Playproof/src/features/team/types/types.ts
@@ -27,13 +27,6 @@ export interface Schedule {
   }[];
 }
 
-// 클립 정보
-export interface Clip {
-  id: string;
-  date: string;
-  thumbnailUrl: string;
-}
-
 export interface CustomMatchSchedule {
   id: string;
   title: string;

--- a/Playproof/src/features/team/types/types.ts
+++ b/Playproof/src/features/team/types/types.ts
@@ -1,7 +1,7 @@
-// src/features/team/types.ts
+// src/features/team/types/types.ts
 import type { User } from '@/types'; 
 
-// 채널 정보 (Team/Azit 전용)
+// 채널 정보
 export interface Channel {
   id: string;
   name: string;
@@ -9,22 +9,25 @@ export interface Channel {
   connectedUsers?: User[];
 }
 
-// 일정 정보 (Team/Azit 전용)
+// 일정 정보 (UI 조건 처리를 위한 필드 추가)
 export interface Schedule {
   id: string;
   title: string;
   dateStr: string;
   timeStr: string;
-  fullDate: Date;
-  isCompleted?: boolean;
-  needMembers?: boolean;
+  fullDate: Date; // 마감/게임 시간
+  
+  hostId: string;       // 방장 ID (모집중 상태 판단용)
+  maxMembers: number;   // 목표 인원 (추가 게이머 찾기 조건용)
+  isFeedbackDone?: boolean; // 피드백 완료 여부 (완료됨 상태용)
+
   participants: {
     user: User | null;
     status: 'JOIN' | 'DECLINE' | 'PENDING';
   }[];
 }
 
-// 클립 정보 (Team/Azit 전용)
+// 클립 정보
 export interface Clip {
   id: string;
   date: string;
@@ -33,9 +36,9 @@ export interface Clip {
 
 export interface CustomMatchSchedule {
   id: string;
-  title: string;        // 유저가 직접 입력하는 제목
-  startTime: string;    // 시작 시간 (예: "20:00")
-  targetDate: Date;     // 매칭 마감 시각 (카운트다운 기준)
+  title: string;
+  startTime: string;
+  targetDate: Date;
   currentParticipants: number;
   maxParticipants: number;
   status: '모집중' | '매칭완료';

--- a/Playproof/src/features/team/utils/pendingFeedback.ts
+++ b/Playproof/src/features/team/utils/pendingFeedback.ts
@@ -1,0 +1,48 @@
+export type PendingFeedback = {
+  scheduleId: string;
+  azitId?: number;
+  targetName: string;
+  scheduleTitle?: string;
+};
+
+const STORAGE_KEY = "playproof.pendingFeedbacks";
+
+const safeParse = (value: string | null): PendingFeedback[] => {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as PendingFeedback[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const getPendingFeedbacks = (): PendingFeedback[] => {
+  if (typeof window === "undefined") return [];
+  return safeParse(window.localStorage.getItem(STORAGE_KEY));
+};
+
+export const setPendingFeedbacks = (items: PendingFeedback[]) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+};
+
+export const addPendingFeedback = (item: PendingFeedback) => {
+  const existing = getPendingFeedbacks();
+  if (
+    existing.some(
+      (it) => it.scheduleId === item.scheduleId && it.azitId === item.azitId
+    )
+  )
+    return;
+  setPendingFeedbacks([...existing, item]);
+};
+
+export const removePendingFeedback = (scheduleId: string, azitId?: number) => {
+  const existing = getPendingFeedbacks();
+  setPendingFeedbacks(
+    existing.filter(
+      (it) => !(it.scheduleId === scheduleId && it.azitId === azitId)
+    )
+  );
+};

--- a/Playproof/src/features/team/utils/scheduleAction.ts
+++ b/Playproof/src/features/team/utils/scheduleAction.ts
@@ -1,0 +1,106 @@
+import type { Schedule } from "@/features/team/types/types";
+
+export type ScheduleActionStatus =
+  | "FEEDBACK_DONE"
+  | "RECRUITMENT_FAILED"
+  | "TIME_OVER"
+  | "CREATOR"
+  | "JOINED"
+  | "DECLINED"
+  | "PENDING";
+
+type ScheduleActionState = {
+  status: ScheduleActionStatus;
+  joinedParticipants: Schedule["participants"];
+  joinedCount: number;
+  myStatus: "JOIN" | "DECLINE" | "PENDING";
+  isTimeOver: boolean;
+  isRecruitmentFailed: boolean;
+  isCreator: boolean;
+};
+
+export const getScheduleActionState = (
+  schedule: Schedule,
+  currentUserId: string
+): ScheduleActionState => {
+  const now = new Date();
+  const isTimeOver = now.getTime() >= schedule.fullDate.getTime();
+  const joinedParticipants = schedule.participants.filter((p) => p.status === "JOIN");
+  const joinedCount = joinedParticipants.length;
+  const myInfo = schedule.participants.find(
+    (p) => String(p.user?.id) === String(currentUserId)
+  );
+  const myStatus = myInfo?.status ?? "PENDING";
+  const isCreator = String(schedule.hostId) === String(currentUserId);
+  const isRecruitmentFailed = isTimeOver && joinedCount < schedule.maxMembers;
+
+  if (schedule.isFeedbackDone) {
+    return {
+      status: "FEEDBACK_DONE",
+      joinedParticipants,
+      joinedCount,
+      myStatus,
+      isTimeOver,
+      isRecruitmentFailed,
+      isCreator,
+    };
+  }
+
+  if (isTimeOver) {
+    return {
+      status: isRecruitmentFailed ? "RECRUITMENT_FAILED" : "TIME_OVER",
+      joinedParticipants,
+      joinedCount,
+      myStatus,
+      isTimeOver,
+      isRecruitmentFailed,
+      isCreator,
+    };
+  }
+
+  if (isCreator) {
+    return {
+      status: "CREATOR",
+      joinedParticipants,
+      joinedCount,
+      myStatus,
+      isTimeOver,
+      isRecruitmentFailed,
+      isCreator,
+    };
+  }
+
+  if (myStatus === "JOIN") {
+    return {
+      status: "JOINED",
+      joinedParticipants,
+      joinedCount,
+      myStatus,
+      isTimeOver,
+      isRecruitmentFailed,
+      isCreator,
+    };
+  }
+
+  if (myStatus === "DECLINE") {
+    return {
+      status: "DECLINED",
+      joinedParticipants,
+      joinedCount,
+      myStatus,
+      isTimeOver,
+      isRecruitmentFailed,
+      isCreator,
+    };
+  }
+
+  return {
+    status: "PENDING",
+    joinedParticipants,
+    joinedCount,
+    myStatus,
+    isTimeOver,
+    isRecruitmentFailed,
+    isCreator,
+  };
+};

--- a/Playproof/src/types.ts
+++ b/Playproof/src/types.ts
@@ -34,4 +34,7 @@ export interface Clip {
   id: string;
   date: string;
   thumbnailUrl: string;
+  mediaType?: 'image' | 'video';
+  mediaUrl?: string;
+  durationLabel?: string;
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ src/
 ├── assets/              # 이미지, 폰트 등 정적 리소스
 ├── components/          # 전역 공통 UI (Button, Modal 등)
 │   └── ui/              # 디자인 시스템 기반의 원자 단위 컴포넌트
+│       └── ModalShell.tsx
 │
 ├── data/                # Mock Data (개발용 더미 데이터) ⭐️ (New)
 ├── types.ts             # 전역 공통 타입 정의 ⭐️ (New)
@@ -76,6 +77,18 @@ src/
 │   ├── auth/            # 로그인, 회원가입
 │   ├── user/            # 프로필, TS(신뢰지수), 매너 평가
 │   ├── team/            # 아지트, 팀 캘린더, 엠블럼
+│   │   ├── components/
+│   │   │   ├── azit/
+│   │   │   ├── feedback/
+│   │   │   └── schedule/
+│   │   ├── hooks/
+│   │   │   ├── useAzitFeedback.ts
+│   │   │   ├── useAzitMedia.ts
+│   │   │   ├── useAzitMediaViewer.ts
+│   │   │   ├── useAzitRooms.ts
+│   │   │   └── useAzitSchedules.ts
+│   │   └── utils/
+│   │       └── pendingFeedback.ts
 │   ├── matching/        # 매칭 필터 리스트
 │   └── chat/            # 채팅방, 미디어 아카이브
 │

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ React, TypeScript, Vite를 기반으로 하며, 유지보수성을 위해 **기�
 
 | 분류 | 기술 | 비고 |
 | :--- | :--- | :--- |
-| **Core** | ![React](https://img.shields.io/badge/React-19-blue) ![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue) | UI 라이브러리 및 언어 |
-| **Build** | ![Vite](https://img.shields.io/badge/Vite-7.0-purple) | 빌드 도구 및 개발 서버 |
+| **Core** | ![React](https://img.shields.io/badge/React-18-blue) ![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue) | UI 라이브러리 및 언어 |
+| **Build** | ![Vite](https://img.shields.io/badge/Vite-7.2-purple) | 빌드 도구 및 개발 서버 |
 | **State** | **TanStack Query** (Server), **Zustand** (Client) | 서버/클라이언트 상태 관리 분리 |
 | **Network** | **Axios** | HTTP 비동기 통신 라이브러리 |
 | **Style** | ![TailwindCSS](https://img.shields.io/badge/TailwindCSS-4.0-38B2AC) | CSS |
 | **Routing** | **React Router DOM** | SPA 라우팅 |
+| **Date** | **React Day Picker** | 캘린더/날짜 선택 UI |
+| **Icons** | **lucide-react** | 아이콘 라이브러리 |
 | **Pkg Mgr** | **npm** | 패키지 매니저 |
 | **Quality** | ESLint, Prettier | 코드 품질 및 포맷팅 (수동 실행) |
 


### PR DESCRIPTION
# feat: 아지트 시스템 전면 개편 및 반응형 UI/UX 고도화

## 개요
- 아지트 페이지의 핵심 기능(스케줄, 채팅, 미디어, 피드백)을 구현하고, 모바일 환경을 고려한 반응형 UI 시스템을 구축했습니다.
- 실제 네트워크 연동 전, 클라이언트 상태(State) 기반의 **실시간 UI 경험**을 완성도 있게 구현하는 데 집중했습니다.
- 프로젝트 구조 변경 사항을 문서화하고, UI 라이브러리 및 캘린더 패키지를 최신화했습니다.

---

## 주요 변경 사항

### 1. 반응형 UI 및 UX 개선
- **아지트 레이아웃**: 데스크탑(3-Panel) 구조를 모바일에서는 **수직 스택(Stack)** 형태로 자동 전환되도록 개선했습니다.
- **하이라이트 상세**: 모바일 뷰에서 댓글 섹션이 이미지 하단으로 자연스럽게 배치되도록 레이아웃을 분기 처리했습니다.
- **네비게이션**: 모바일 환경을 위한 **햄버거 메뉴(Drawer)** 및 네비바 동작을 추가하여 접근성을 높였습니다.
- **스크롤 제어**: 모달 오픈 시 배경 스크롤을 잠그는 로직을 전역적으로 적용해 UX를 개선했습니다.

### 2. 아지트 채팅 및 음성 룸 고도화
- **UI 경험**: 소켓 연동 전 단계로서, 클라이언트 상태 관리를 통해 끊김 없는 **실시간 채팅/음성 UI 인터랙션**을 구현했습니다.
- **방 관리**: 채팅방/음성방 생성뿐만 아니라 **이름 수정, 삭제 기능**을 추가하고, 삭제 시 확인 모달을 통해 오동작을 방지했습니다.
- **구조 개선**: 음성/일반 채팅 섹션 분리 및 상단 "채팅" 박스 UI를 직관적으로 개편했습니다.

### 3. 스케줄 관리 및 미디어 연동
- **스케줄링**: `useAzitSchedules` 훅을 통해 스케줄 생성, 모집, 상태 변경(신청/거절/완료) 로직을 체계화했습니다.
- **공유 플로우**: 채팅 및 클립 상세 화면에서 **"공유" 버튼 클릭 시, 해당 이미지가 하이라이트 글쓰기 모달로 자동 주입**되는 UX 플로우를 구현했습니다.
- **뷰어**: 영상 플레이 오버레이, 시간 배지 표시 및 **좌우 넘김(Carousel)** 기능을 지원하여 미디어 탐색 편의성을 강화했습니다.
- **최근 클립**: 이미지/영상 전송 시 **최근 클립** 섹션에 즉시 반영되며, "전체보기" 클릭 시 하이라이트 페이지로 이동하도록 연결했습니다.

### 4. 피드백 플로우 (Flow A/B/C)
- **강제 노출 로직**: 사용자 참여율을 높이기 위해 아래 3가지 시점에 미작성 피드백 모달을 노출합니다.
  - **Flow A**: 일정 종료 직후 버튼 클릭
  - **Flow B**: 아지트 상단 '돌아가기' 버튼 클릭
  - **Flow C**: 파티찾기 메인 진입 시
- **평가 UI**: 긍/부정 태그, 메모, '다시 만나지 않기' 등 평가 폼 UI를 구현했습니다.

### 5. 문서 및 패키지 현행화
- **README 업데이트**: 변경된 폴더 구조 및 주요 기능 설명을 문서에 최신화했습니다.
- **패키지 반영**: `react-day-picker`(캘린더), `lucide-react`(아이콘) 등 추가/갱신된 의존성 정보를 `package.json` 및 문서에 반영했습니다.

---

## 테스트 결과
- [x] **[반응형]** 모바일 진입 시 아지트 패널이 수직으로 쌓이고 네비바 햄버거 메뉴가 정상 동작함.
- [x] **[반응형]** 하이라이트 상세 모달에서 댓글창이 하단으로 재배치되며 스크롤이 정상적으로 됨.
- [x] **[UX]** 모달 오픈 시 백그라운드 스크롤이 잠기고 닫으면 해제됨.
- [x] 채팅방 이름 수정 및 삭제(확인 모달 포함) 동작 확인.
- [x] 미디어 뷰어에서 좌우 화살표/스와이프로 이미지 넘김 동작 확인.
- [x] **[공유]** 클립 상세에서 공유 버튼 클릭 시 하이라이트 작성 모달에 이미지가 첨부된 상태로 열림.
- [x] 아지트 이탈 시 미작성 피드백 모달 강제 노출(Flow B) 정상 동작.

---

## 관련 이슈
- Closes #47 
- Closes #48 
- Closes #49 
- Closes #50 
- Closes #51 

---

## 기타
- 관련 브랜치: `feat/azit-system-overhaul_Elric`