### PR TITLE
[Feat] 아지트 API 연동 완료 (일정/멤버/관리) 및 채팅 미디어 기능 구현

### DIFF
--- a/Playproof/src/features/community/pages/CommunityPageView.tsx
+++ b/Playproof/src/features/community/pages/CommunityPageView.tsx
@@ -35,7 +35,10 @@ export const CommunityPageView = () => {
     }
     setSharedFiles(shareState.shareFiles);
     actions.modal.setWriteOpen(true);
-    navigate(`${location.pathname}${location.search}`, { replace: true, state: {} });
+    const params = new URLSearchParams(location.search);
+    params.delete("write");
+    const nextSearch = params.toString();
+    navigate(`${location.pathname}${nextSearch ? `?${nextSearch}` : ""}`, { replace: true, state: {} });
   }, [
     actions.modal,
     actions.tab,

--- a/Playproof/src/features/team/api/azitApi.ts
+++ b/Playproof/src/features/team/api/azitApi.ts
@@ -31,3 +31,28 @@ export async function getAzits(): Promise<Azit[]> {
   const list = res.data.data?.azits ?? [];
   return list.map(normalizeAzit);
 }
+
+export async function updateAzit(
+  azitId: number,
+  payload: { azit_name?: string | null; azit_icon?: File | null; is_delete_icon?: boolean }
+): Promise<AzitResDto> {
+  const formData = new FormData();
+  if (payload.azit_name !== undefined) {
+    formData.append("azit_name", payload.azit_name ?? "");
+  }
+  if (payload.is_delete_icon !== undefined) {
+    formData.append("is_delete_icon", String(payload.is_delete_icon));
+  }
+  if (payload.azit_icon) {
+    formData.append("azit_icon", payload.azit_icon);
+  }
+
+  const res = await api.patch<ApiResponse<AzitResDto>>(`/azits/${azitId}`, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+
+  if (res.data.error || res.data.statusCode !== 200) {
+    throw new Error(res.data.error?.message ?? "아지트 설정 변경 실패");
+  }
+  return res.data.data;
+}

--- a/Playproof/src/features/team/api/azitApi.ts
+++ b/Playproof/src/features/team/api/azitApi.ts
@@ -1,0 +1,33 @@
+// src/features/team/api/azitApi.ts
+
+import { api } from "@/services/api";
+import type { Azit } from "@/features/team/types/types";
+
+type AzitResDto = {
+  azit_id: number;
+  azit_name: string;
+  azit_icon_url: string | null;
+  member_count?: number;
+};
+
+type ApiResponse<T> = {
+  statusCode: number;
+  data: T;
+  error: null | { code: string; message: string; errors?: unknown[] };
+};
+
+const normalizeAzit = (item: AzitResDto): Azit => ({
+  id: item.azit_id,
+  name: item.azit_name,
+  icon: item.azit_icon_url ?? "",
+  memberCount: item.member_count ?? 0,
+});
+
+export async function getAzits(): Promise<Azit[]> {
+  const res = await api.get<ApiResponse<{ azits: AzitResDto[] }>>("/azits");
+  if (res.data.error || res.data.statusCode !== 200) {
+    throw new Error(res.data.error?.message ?? "아지트 목록 조회 실패");
+  }
+  const list = res.data.data?.azits ?? [];
+  return list.map(normalizeAzit);
+}

--- a/Playproof/src/features/team/api/azitMemberApi.ts
+++ b/Playproof/src/features/team/api/azitMemberApi.ts
@@ -1,0 +1,50 @@
+// src/features/team/api/azitMemberApi.ts
+
+import { api } from "@/services/api";
+import type { User } from "@/types";
+
+type ApiResponse<T> = {
+  statusCode: number;
+  data: T;
+  error: null | { code: string; message: string; errors?: unknown[] };
+};
+
+type AzitMemberResDto = {
+  member_id: number;
+  nickname: string | null;
+  avatar_url: string | null;
+  role: string;
+};
+
+type GetAzitMembersResDto = {
+  azit_id: number;
+  azit_name: string;
+  members: AzitMemberResDto[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};
+
+export async function getAzitMembers(params: {
+  azitId: number;
+  page?: number;
+  size?: number;
+}): Promise<GetAzitMembersResDto> {
+  const { azitId, page = 1, size = 20 } = params;
+  const res = await api.get<ApiResponse<GetAzitMembersResDto>>(
+    `/azits/${azitId}/members`,
+    { params: { page, size } }
+  );
+  if (res.data.error || res.data.statusCode !== 200) {
+    throw new Error(res.data.error?.message ?? "아지트 멤버 조회 실패");
+  }
+  return res.data.data;
+}
+
+export function mapAzitMembersToUsers(members: AzitMemberResDto[]): User[] {
+  return members.map((m) => ({
+    id: String(m.member_id),
+    nickname: m.nickname ?? "Unknown",
+    avatarUrl: m.avatar_url ?? undefined,
+    isOnline: false,
+  }));
+}

--- a/Playproof/src/features/team/api/azitScheduleApi.ts
+++ b/Playproof/src/features/team/api/azitScheduleApi.ts
@@ -1,0 +1,145 @@
+// src/features/team/api/azitScheduleApi.ts
+
+import { api } from "@/services/api";
+
+export type ApiError = {
+  code: string;
+  message: string;
+  errors?: { field: string; value: unknown; reason: string }[];
+};
+
+export type Result<T> =
+  | { statusCode: number; data: T; error: null }
+  | { statusCode: number; data: null; error: ApiError };
+
+export type AzitScheduleParticipantResDto = {
+  member_id: number;
+  nickname: string | null;
+  avatar_url: string | null;
+};
+
+export type AzitScheduleParticipationStatus = "JOIN" | "DECLINE" | "PENDING" | "CANCELLED";
+
+export type AzitScheduleCreateReqDto = {
+  title: string;
+  max_participants: number;
+  game_start_at: string;
+  game_end_at: string;
+  recruitment_end_at: string;
+};
+
+export type AzitScheduleDetailResDto = {
+  schedule_id: number;
+  title: string;
+  max_participants: number;
+  game_start_at: string;
+  game_end_at: string;
+  recruitment_end_at: string;
+  current_participants: number;
+  is_participated: boolean;
+  participants: AzitScheduleParticipantResDto[];
+};
+
+export type AzitScheduleResDto = {
+  schedule_id: number;
+  title: string;
+  max_participants: number;
+  game_start_at: string;
+  game_end_at: string;
+  recruitment_end_at: string;
+};
+
+export type AzitScheduleListResDto = {
+  schedules: AzitScheduleDetailResDto[];
+  nextCursor: string | null;
+  hasNext: boolean;
+};
+
+export async function getAzitSchedules(params: {
+  azitId: number;
+  cursor?: string | null;
+  size?: number;
+}): Promise<AzitScheduleListResDto> {
+  const { azitId, cursor, size } = params;
+  const qs = new URLSearchParams();
+  if (cursor) qs.set("cursor", cursor);
+  if (size) qs.set("size", String(size));
+
+  const res = await api.get<Result<AzitScheduleListResDto>>(
+    `/azits/${azitId}/schedules${qs.toString() ? `?${qs.toString()}` : ""}`
+  );
+  if (res.data.error || res.data.statusCode !== 200) {
+    throw new Error(res.data.error?.message ?? "스케줄 목록 조회 실패");
+  }
+  return res.data.data;
+}
+
+export async function createAzitSchedule(params: {
+  azitId: number;
+  payload: AzitScheduleCreateReqDto;
+}): Promise<AzitScheduleResDto> {
+  const { azitId, payload } = params;
+  const res = await api.post<Result<AzitScheduleResDto>>(`/azits/${azitId}/schedules`, payload);
+  if (res.data.error || (res.data.statusCode !== 200 && res.data.statusCode !== 201)) {
+    throw new Error(res.data.error?.message ?? "스케줄 생성 실패");
+  }
+  return res.data.data;
+}
+
+export async function joinAzitScheduleParticipant(params: {
+  azitId: number;
+  scheduleId: string | number;
+}) {
+  const { azitId, scheduleId } = params;
+  const res = await api.post<Result<null>>(
+    `/azits/${azitId}/schedules/${scheduleId}/participants`
+  );
+  if (res.data.error) {
+    throw new Error(res.data.error.message);
+  }
+  return res.data.data;
+}
+
+export async function updateAzitScheduleParticipantStatus(params: {
+  azitId: number;
+  scheduleId: string | number;
+  status: AzitScheduleParticipationStatus;
+}) {
+  const { azitId, scheduleId, status } = params;
+  const res = await api.patch<Result<null>>(
+    `/azits/${azitId}/schedules/${scheduleId}/participants`,
+    { is_participation: status }
+  );
+  if (res.data.error) {
+    throw new Error(res.data.error.message);
+  }
+  return res.data.data;
+}
+
+export async function leaveAzitScheduleParticipant(params: {
+  azitId: number;
+  scheduleId: string | number;
+}) {
+  const { azitId, scheduleId } = params;
+  const res = await api.delete<Result<null>>(
+    `/azits/${azitId}/schedules/${scheduleId}/participants`
+  );
+  if (res.data.error) {
+    throw new Error(res.data.error.message);
+  }
+  return res.data.data;
+}
+
+export async function getAzitScheduleMyParticipationStatus(params: {
+  azitId: number;
+  scheduleId: string | number;
+}): Promise<AzitScheduleParticipationStatus | null> {
+  const { azitId, scheduleId } = params;
+  const res = await api.get<Result<{ is_participation: AzitScheduleParticipationStatus }>>(
+    `/azits/${azitId}/schedules/${scheduleId}/participants/me`
+  );
+  if (res.data.error) {
+    return null;
+  }
+  return res.data.data.is_participation ?? null;
+}

--- a/Playproof/src/features/team/api/chatApi.ts
+++ b/Playproof/src/features/team/api/chatApi.ts
@@ -26,6 +26,7 @@ export type ChatMessageResDto = {
   userId: number;
   nickname?: string | null;
   content: string;
+  mediaUrls?: string[];
   createdAt: string;
 };
 
@@ -114,6 +115,34 @@ export async function getChatMessages(params: {
     },
   });
 
+  if (json.error) throw new Error(json.error.message);
+  return json.data;
+}
+
+export async function uploadChatImage(params: {
+  apiBaseUrl: string;
+  accessToken: string;
+  roomId: number;
+  file: File;
+}): Promise<{ mediaUrl: string }> {
+  const base = normalizeBase(params.apiBaseUrl);
+  const url = `${base}/chat-rooms/${params.roomId}/upload`;
+  const formData = new FormData();
+  formData.append("file", params.file);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      Accept: "application/json",
+    },
+    body: formData,
+  });
+
+  const json = (await res.json().catch(() => null)) as Result<{ mediaUrl: string }> | null;
+  if (!json) {
+    throw new Error(`API 응답 파싱 실패 (status=${res.status})`);
+  }
   if (json.error) throw new Error(json.error.message);
   return json.data;
 }

--- a/Playproof/src/features/team/api/chatApi.ts
+++ b/Playproof/src/features/team/api/chatApi.ts
@@ -118,6 +118,53 @@ export async function getChatMessages(params: {
   return json.data;
 }
 
+export async function updateChatRoom(params: {
+  apiBaseUrl: string;
+  accessToken: string;
+  roomId: number;
+  name?: string;
+  isPrivate?: boolean;
+}): Promise<ChatRoomGetResDto> {
+  const base = normalizeBase(params.apiBaseUrl);
+  const url = `${base}/chat-rooms/${params.roomId}`;
+  const body: Record<string, unknown> = {};
+  if (params.name !== undefined) body.roomName = params.name;
+  if (params.isPrivate !== undefined) body.isPrivate = params.isPrivate;
+
+  const json = await fetchJson<Result<ChatRoomGetResDto>>(url, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (json.error) throw new Error(json.error.message);
+  return json.data;
+}
+
+export async function deleteChatRoom(params: {
+  apiBaseUrl: string;
+  accessToken: string;
+  roomId: number;
+}) {
+  const base = normalizeBase(params.apiBaseUrl);
+  const url = `${base}/chat-rooms/${params.roomId}`;
+
+  const json = await fetchJson<Result<string>>(url, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (json.error) throw new Error(json.error.message);
+  return json.data;
+}
+
 /**
  * Alias for chat message list fetch (hook-friendly name).
  * Backend contract: cursor-based pagination (not limit/beforeId).

--- a/Playproof/src/features/team/components/azit/AzitSettingsModal.tsx
+++ b/Playproof/src/features/team/components/azit/AzitSettingsModal.tsx
@@ -7,9 +7,8 @@ type AzitSettingsModalProps = {
   open: boolean;
   onClose: () => void;
   profileUrl?: string;
-  onUpdateProfile?: (url: string) => void;
   initialName?: string;
-  onUpdateName?: (name: string) => void;
+  onSave?: (payload: { name?: string; file?: File | null }) => void;
   onSubmit?: () => void;
 };
 
@@ -17,9 +16,8 @@ export const AzitSettingsModal: React.FC<AzitSettingsModalProps> = ({
   open,
   onClose,
   profileUrl: initialProfileUrl,
-  onUpdateProfile,
   initialName,
-  onUpdateName,
+  onSave,
   onSubmit,
 }) => {
   const [name, setName] = React.useState("");
@@ -29,6 +27,7 @@ export const AzitSettingsModal: React.FC<AzitSettingsModalProps> = ({
   const [showKick, setShowKick] = React.useState(false);
   const [deleteReason, setDeleteReason] = React.useState("");
   const [profileUrl, setProfileUrl] = React.useState<string>("");
+  const [profileFile, setProfileFile] = React.useState<File | null>(null);
   const fileRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
@@ -40,6 +39,7 @@ export const AzitSettingsModal: React.FC<AzitSettingsModalProps> = ({
     setShowKick(false);
     setDeleteReason("");
     setProfileUrl(initialProfileUrl ?? "");
+    setProfileFile(null);
   }, [open, initialProfileUrl, initialName]);
 
   React.useEffect(() => {
@@ -56,24 +56,24 @@ export const AzitSettingsModal: React.FC<AzitSettingsModalProps> = ({
     if (profileUrl) URL.revokeObjectURL(profileUrl);
     const nextUrl = URL.createObjectURL(file);
     setProfileUrl(nextUrl);
+    setProfileFile(file);
     e.target.value = "";
   };
 
+  const trimmedName = name.trim();
   const isDirty =
-    profileUrl !== (initialProfileUrl ?? "") ||
-    (name.trim() !== (initialName ?? "")) ||
+    profileFile !== null ||
+    trimmedName !== (initialName ?? "") ||
     Boolean(transferTo.trim()) ||
     Boolean(kickMember.trim()) ||
     Boolean(deleteReason.trim());
 
   const handleSubmit = () => {
     if (!isDirty) return;
-    if (profileUrl !== (initialProfileUrl ?? "")) {
-      onUpdateProfile?.(profileUrl);
-    }
-    if (name.trim() !== (initialName ?? "")) {
-      onUpdateName?.(name);
-    }
+    onSave?.({
+      name: trimmedName !== (initialName ?? "") ? trimmedName : undefined,
+      file: profileFile,
+    });
     onSubmit?.();
     onClose();
   };

--- a/Playproof/src/features/team/components/azit/MainPanel.tsx
+++ b/Playproof/src/features/team/components/azit/MainPanel.tsx
@@ -38,6 +38,8 @@ export const MainPanel: React.FC<MainPanelProps> = ({
   const messagesEndRef = React.useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = React.useRef<HTMLDivElement | null>(null);
   const pendingScrollRef = React.useRef(false);
+  const lastRoomIdRef = React.useRef<number | null>(null);
+  const lastMessageCountRef = React.useRef(0);
 
   const hasContent = message.trim().length > 0 || selectedFiles.length > 0;
 
@@ -98,7 +100,7 @@ export const MainPanel: React.FC<MainPanelProps> = ({
     const file = new File([blob], `highlight-share-${Date.now()}.${ext}`, {
       type: blob.type || "image/jpeg",
     });
-    navigate("/community?tab=하이라이트", { state: { shareFiles: [file] } });
+    navigate("/community?tab=하이라이트&write=1", { state: { shareFiles: [file] } });
   }, [activeMedia, navigate]);
 
   const safeMessages = messages ?? [];
@@ -108,12 +110,20 @@ export const MainPanel: React.FC<MainPanelProps> = ({
   }, []);
 
   React.useEffect(() => {
-    if (!roomId) return;
+    if (!roomId) {
+      lastRoomIdRef.current = null;
+      lastMessageCountRef.current = 0;
+      return;
+    }
     const container = scrollContainerRef.current;
     if (!container) return;
+
+    const isRoomChanged = lastRoomIdRef.current !== roomId;
+    const isNewMessages = safeMessages.length > lastMessageCountRef.current;
     const nearBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight < 120;
-    if (pendingScrollRef.current || nearBottom) {
+
+    if (isRoomChanged || isNewMessages || pendingScrollRef.current || nearBottom) {
       scrollToBottom();
       if (pendingScrollRef.current) {
         window.setTimeout(() => {
@@ -121,6 +131,9 @@ export const MainPanel: React.FC<MainPanelProps> = ({
         }, 300);
       }
     }
+
+    lastRoomIdRef.current = roomId;
+    lastMessageCountRef.current = safeMessages.length;
   }, [roomId, safeMessages.length, scrollToBottom]);
 
   return (

--- a/Playproof/src/features/team/components/azit/MainPanel.tsx
+++ b/Playproof/src/features/team/components/azit/MainPanel.tsx
@@ -114,9 +114,6 @@ export const MainPanel: React.FC<MainPanelProps> = ({
     <main className="flex-1 flex flex-col w-full min-w-0 lg:min-w-[400px] h-auto lg:h-full">
       <div className="flex-none h-12 flex items-center gap-2 mb-2 px-1">
         <h2 className="text-lg font-bold text-gray-900">{roomName || "채팅"}</h2>
-        <button className="text-gray-400 hover:bg-gray-100 p-0.5 rounded transition-colors">
-          <Plus className="w-5 h-5" />
-        </button>
       </div>
 
       <div className="flex-1 bg-white border border-gray-200 rounded-xl shadow-sm flex flex-col overflow-hidden relative">

--- a/Playproof/src/features/team/components/azit/MainPanel.tsx
+++ b/Playproof/src/features/team/components/azit/MainPanel.tsx
@@ -10,6 +10,7 @@ type MainPanelProps = {
   roomName: string;
   messages: ChatMessageUI[];
   onSendMessage: (roomId: number, content: string, files: File[]) => void;
+  currentUserId?: string;
   currentUserName: string;
 };
 
@@ -23,6 +24,7 @@ export const MainPanel: React.FC<MainPanelProps> = ({
   roomName,
   messages,
   onSendMessage,
+  currentUserId,
   currentUserName,
 }) => {
   const [activeMedia, setActiveMedia] = React.useState<{ url: string; type: "image" | "video" } | null>(null);
@@ -35,6 +37,7 @@ export const MainPanel: React.FC<MainPanelProps> = ({
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const messagesEndRef = React.useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = React.useRef<HTMLDivElement | null>(null);
+  const pendingScrollRef = React.useRef(false);
 
   const hasContent = message.trim().length > 0 || selectedFiles.length > 0;
 
@@ -72,6 +75,7 @@ export const MainPanel: React.FC<MainPanelProps> = ({
     if (!roomId) return;
 
     onSendMessage(roomId, message, selectedFiles);
+    pendingScrollRef.current = true;
 
     // 전송 후 로컬 상태 초기화
     setMessage("");
@@ -99,16 +103,25 @@ export const MainPanel: React.FC<MainPanelProps> = ({
 
   const safeMessages = messages ?? [];
 
+  const scrollToBottom = React.useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, []);
+
   React.useEffect(() => {
     if (!roomId) return;
     const container = scrollContainerRef.current;
     if (!container) return;
     const nearBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight < 120;
-    if (nearBottom) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    if (pendingScrollRef.current || nearBottom) {
+      scrollToBottom();
+      if (pendingScrollRef.current) {
+        window.setTimeout(() => {
+          pendingScrollRef.current = false;
+        }, 300);
+      }
     }
-  }, [roomId, safeMessages.length]);
+  }, [roomId, safeMessages.length, scrollToBottom]);
 
   return (
     <main className="flex-1 flex flex-col w-full min-w-0 lg:min-w-[400px] h-auto lg:h-full">
@@ -127,11 +140,14 @@ export const MainPanel: React.FC<MainPanelProps> = ({
             </div>
           ) : (
             safeMessages.map((item) => {
-              const isMine = item.author === currentUserName;
+              const isMine =
+                (currentUserId && item.userId
+                  ? String(item.userId) === String(currentUserId)
+                  : item.author === currentUserName);
               return (
                 <div
                   key={item.id}
-                  className={`flex flex-col gap-2 mb-4 ${isMine ? "items-end" : "items-start"}`}
+                  className={`w-full flex flex-col gap-2 mb-4 ${isMine ? "items-end" : "items-start"}`}
                 >
                   <div className="flex items-center gap-2 text-xs text-gray-500">
                     <span className="font-semibold text-gray-700">{item.author}</span>
@@ -145,6 +161,35 @@ export const MainPanel: React.FC<MainPanelProps> = ({
                       }`}
                     >
                       {item.content}
+                    </div>
+                  ) : null}
+
+                  {item.mediaUrls && item.mediaUrls.length > 0 ? (
+                    <div
+                      className={`flex flex-wrap gap-2 max-w-[75%] w-fit ${
+                        isMine ? "self-end justify-end" : "self-start justify-start"
+                      }`}
+                    >
+                      {item.mediaUrls.map((url, idx) => (
+                        <button
+                          key={`${item.id}-media-${idx}`}
+                          type="button"
+                          onClick={() => setActiveMedia({ url, type: "image" })}
+                          className="w-32 h-24 rounded-lg border border-gray-200 overflow-hidden bg-gray-50"
+                        >
+                          <img
+                            src={url}
+                            alt="chat media"
+                            className="w-full h-full object-cover"
+                            onLoad={() => {
+                              if (pendingScrollRef.current) {
+                                scrollToBottom();
+                                pendingScrollRef.current = false;
+                              }
+                            }}
+                          />
+                        </button>
+                      ))}
                     </div>
                   ) : null}
                 </div>
@@ -192,7 +237,7 @@ export const MainPanel: React.FC<MainPanelProps> = ({
         <div className="p-4 bg-white border-t border-gray-100">
           <input
             type="file"
-            accept="image/*,video/*"
+            accept="image/*"
             multiple
             ref={fileInputRef}
             onChange={handleFileSelect}

--- a/Playproof/src/features/team/components/azit/MainPanel.tsx
+++ b/Playproof/src/features/team/components/azit/MainPanel.tsx
@@ -33,6 +33,8 @@ export const MainPanel: React.FC<MainPanelProps> = ({
   const [selectedFiles, setSelectedFiles] = React.useState<File[]>([]);
   const [previewItems, setPreviewItems] = React.useState<PreviewItem[]>([]);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const messagesEndRef = React.useRef<HTMLDivElement | null>(null);
+  const scrollContainerRef = React.useRef<HTMLDivElement | null>(null);
 
   const hasContent = message.trim().length > 0 || selectedFiles.length > 0;
 
@@ -97,6 +99,17 @@ export const MainPanel: React.FC<MainPanelProps> = ({
 
   const safeMessages = messages ?? [];
 
+  React.useEffect(() => {
+    if (!roomId) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const nearBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight < 120;
+    if (nearBottom) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    }
+  }, [roomId, safeMessages.length]);
+
   return (
     <main className="flex-1 flex flex-col w-full min-w-0 lg:min-w-[400px] h-auto lg:h-full">
       <div className="flex-none h-12 flex items-center gap-2 mb-2 px-1">
@@ -107,7 +120,10 @@ export const MainPanel: React.FC<MainPanelProps> = ({
       </div>
 
       <div className="flex-1 bg-white border border-gray-200 rounded-xl shadow-sm flex flex-col overflow-hidden relative">
-        <div className="flex-1 bg-gray-50 p-4 flex flex-col-reverse overflow-y-auto">
+        <div
+          ref={scrollContainerRef}
+          className="flex-1 bg-gray-50 p-4 flex flex-col overflow-y-auto"
+        >
           {safeMessages.length === 0 ? (
             <div className="text-center text-gray-400 text-sm my-auto">
               {roomId ? "채팅 기록이 없습니다." : "채팅방을 선택해주세요."}
@@ -138,6 +154,7 @@ export const MainPanel: React.FC<MainPanelProps> = ({
               );
             })
           )}
+          <div ref={messagesEndRef} />
         </div>
 
         {/* ✅ 전송 전 프리뷰는 그대로 유지 */}

--- a/Playproof/src/features/team/components/azit/RightPanel.tsx
+++ b/Playproof/src/features/team/components/azit/RightPanel.tsx
@@ -12,31 +12,29 @@ interface RightPanelProps {
 export const RightPanel: React.FC<RightPanelProps> = ({ clips }) => {
   // ✅ 핵심: clips가 배열이 아니면 빈 배열로 강제
   const safeClips: Clip[] = Array.isArray(clips) ? (clips as Clip[]) : [];
+  const previewClips = safeClips.slice(0, 3);
 
   const {
     isGalleryOpen,
     activeMedia,
     hasMedia,
     closeGallery,
+    openGallery,
     openMedia,
     closeMedia,
     goPrev,
     goNext,
-    goHighlight,
     shareToHighlight,
   } = useAzitMediaViewer(safeClips);
 
   return (
     <aside className="w-full lg:w-[320px] bg-gray-50 border-t lg:border-t-0 lg:border-l border-gray-200 flex flex-col h-full overflow-y-auto shrink-0 p-5 gap-6">
-      <div className="text-xs text-gray-500">
-        clips isArray: {String(Array.isArray(clips))} / type: {typeof clips}
-      </div>
 
       <ClipList
-        clips={safeClips}
-        onViewAll={goHighlight}
+        clips={previewClips}
+        onViewAll={openGallery}
         onSelectClip={openMedia}
-        viewAllLabel="하이라이트 전체보기"
+        viewAllLabel="전체보기"
       />
 
       <ModalShell

--- a/Playproof/src/features/team/hooks/useAzitMedia.ts
+++ b/Playproof/src/features/team/hooks/useAzitMedia.ts
@@ -3,7 +3,7 @@
 import React from "react";
 import type { Clip } from "@/features/team/types";
 
-type MediaItem = { url: string; type: "image" | "video" };
+type MediaItem = { url: string; type: "image" | "video"; dateLabel?: string; id?: string };
 
 const formatDuration = (seconds: number) => {
   if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
@@ -45,8 +45,8 @@ export const useAzitMedia = (initialClips: Record<number, Clip[]>) => {
     if (media.length === 0) return;
     const nowLabel = "방금 전";
     const newClips: Clip[] = media.map((item, index) => ({
-      id: `${Date.now()}-${index}`,
-      date: nowLabel,
+      id: item.id ?? `${Date.now()}-${index}`,
+      date: item.dateLabel ?? nowLabel,
       thumbnailUrl: item.type === "image" ? item.url : "",
       mediaType: item.type,
       mediaUrl: item.url,
@@ -88,6 +88,55 @@ export const useAzitMedia = (initialClips: Record<number, Clip[]>) => {
       };
     });
   }, []);
+
+  const replaceClipsFromMedia = React.useCallback(
+    (azitId: number, roomName: string, media: MediaItem[]) => {
+      const nowLabel = "방금 전";
+      const newClips: Clip[] = media.map((item, index) => ({
+        id: item.id ?? `${Date.now()}-${index}`,
+        date: item.dateLabel ?? nowLabel,
+        thumbnailUrl: item.type === "image" ? item.url : "",
+        mediaType: item.type,
+        mediaUrl: item.url,
+        durationLabel: item.type === "video" ? "0:00" : undefined,
+      }));
+
+      setClipsByAzit((prev) => {
+        const currentRooms = prev[azitId] ?? {};
+        return {
+          ...prev,
+          [azitId]: {
+            ...currentRooms,
+            [roomName]: newClips,
+          },
+        };
+      });
+
+      newClips.forEach((clip) => {
+        if (clip.mediaType !== "video" || !clip.mediaUrl) return;
+        const video = document.createElement("video");
+        video.preload = "metadata";
+        video.src = clip.mediaUrl;
+        video.onloadedmetadata = () => {
+          const label = formatDuration(video.duration);
+          setClipsByAzit((prev) => {
+            const currentRooms = prev[azitId] ?? {};
+            const current = currentRooms[roomName] ?? [];
+            return {
+              ...prev,
+              [azitId]: {
+                ...currentRooms,
+                [roomName]: current.map((item) =>
+                  item.id === clip.id ? { ...item, durationLabel: label } : item
+                ),
+              },
+            };
+          });
+        };
+      });
+    },
+    []
+  );
 
   const initAzitClips = React.useCallback((azitId: number) => {
     setClipsByAzit((prev) => ({ ...prev, [azitId]: { "자유 대화": [] } }));
@@ -146,6 +195,7 @@ export const useAzitMedia = (initialClips: Record<number, Clip[]>) => {
     clipsByAzit,
     createMediaItems,
     addClipsFromMedia,
+    replaceClipsFromMedia,
     initAzitClips,
     ensureRoomClips,
     renameRoomClips,

--- a/Playproof/src/features/team/hooks/useAzitMediaViewer.ts
+++ b/Playproof/src/features/team/hooks/useAzitMediaViewer.ts
@@ -60,7 +60,7 @@ export const useAzitMediaViewer = (clips: Clip[]) => {
     const file = new File([blob], `highlight-share-${Date.now()}.${ext}`, {
       type: blob.type || "image/jpeg",
     });
-    navigate("/community?tab=하이라이트", { state: { shareFiles: [file] } });
+    navigate("/community?tab=하이라이트&write=1", { state: { shareFiles: [file] } });
   }, [activeMedia, navigate]);
 
   return {

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -204,7 +204,9 @@ export function useAzitPageLogic() {
     replaceMessagesForRoom,
     appendMessageToRoom,
     voiceRooms,
+    myVoiceRoomId,
     joinVoiceRoom: joinVoiceRoomUI, 
+    leaveVoiceRoom,
     toggleMyMic,
     initAzitRooms,
   } = useAzitRooms(currentAzitId, currentUser);
@@ -240,6 +242,13 @@ export function useAzitPageLogic() {
     try {
       if (!accessToken) {
         alert("로그인 중입니다... 잠시 후 다시 시도해주세요.");
+        return;
+      }
+
+      if (myVoiceRoomId && myVoiceRoomId === roomIdStr) {
+        await socketVoiceLeave(roomId);
+        disconnectLiveKit();
+        leaveVoiceRoom();
         return;
       }
 
@@ -286,7 +295,7 @@ export function useAzitPageLogic() {
     } catch (err) {
       console.error("🔥 음성 채팅 연결 중 에러:", err);
     }
-  }, [socketVoiceJoin, requestVoiceToken, connectLiveKit, accessToken, joinVoiceRoomUI, setAuth]); 
+  }, [socketVoiceJoin, socketVoiceLeave, requestVoiceToken, connectLiveKit, disconnectLiveKit, accessToken, joinVoiceRoomUI, leaveVoiceRoom, myVoiceRoomId, setAuth]); 
 
   React.useEffect(() => {
     if (routeState?.azitId) setCurrentAzitId(routeState.azitId);

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -15,6 +15,7 @@ import {
 } from "@/features/team/data/mockTeamData";
 
 import { getAzits } from "@/features/team/api/azitApi";
+import { getAzitMembers, mapAzitMembersToUsers } from "@/features/team/api/azitMemberApi";
 
 import { useAzitSchedules } from "@/features/team/hooks/useAzitSchedules";
 import { useAzitFeedback } from "@/features/team/hooks/useAzitFeedback";
@@ -54,6 +55,7 @@ export function useAzitPageLogic() {
 
   const [scheduleAnchorEl, setScheduleAnchorEl] = React.useState<HTMLElement | null>(null);
   const [azits, setAzits] = React.useState([]);
+  const [membersByAzit, setMembersByAzit] = React.useState<Record<number, User[]>>({});
   const azitIconUrlsRef = React.useRef<string[]>([]);
   
   // Auth Store 정보 가져오기
@@ -149,6 +151,31 @@ export function useAzitPageLogic() {
       alive = false;
     };
   }, [accessToken, currentAzitId, setCurrentAzitId]);
+
+  React.useEffect(() => {
+    if (!accessToken || !currentAzitId) return;
+    let alive = true;
+    (async () => {
+      try {
+        const res = await getAzitMembers({ azitId: currentAzitId, page: 1, size: 50 });
+        if (!alive) return;
+        const users = mapAzitMembersToUsers(res.members ?? []);
+        setMembersByAzit((prev) => ({ ...prev, [currentAzitId]: users }));
+        setAzits((prev) =>
+          prev.map((azit) =>
+            azit.id === currentAzitId
+              ? { ...azit, memberCount: users.length }
+              : azit
+          )
+        );
+      } catch (err) {
+        console.error("아지트 멤버 조회 실패:", err);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [accessToken, currentAzitId]);
 
   const {
     feedbackModal,
@@ -266,7 +293,7 @@ export function useAzitPageLogic() {
   }, [routeState?.azitId, setCurrentAzitId]);
 
   const currentAzit = azits.find((a) => a.id === currentAzitId) ?? azits[0];
-  const currentMembers = mockMembersByAzit[currentAzitId] ?? [];
+  const currentMembers = membersByAzit[currentAzitId] ?? [];
   const currentClips = clipsByAzit[currentAzitId] ?? [];
 
   const reloadChatRooms = React.useCallback(async () => {

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -7,10 +7,7 @@ import type { User } from "@/features/team/types/types";
 import { useAuthStore } from "@/store/authStore";
 import { login } from "@/services/authApi";
 
-import {
-  mockMembers,
-  mockClipsByAzit,
-} from "@/features/team/data/mockTeamData";
+import { mockMembers } from "@/features/team/data/mockTeamData";
 
 import { getAzits, updateAzit } from "@/features/team/api/azitApi";
 import { getAzitMembers, mapAzitMembersToUsers } from "@/features/team/api/azitMemberApi";
@@ -28,6 +25,7 @@ import {
   getChatRoomsByAzit,
   getChatMessages,
   createChatRoomByAzit,
+  uploadChatImage,
   updateChatRoom,
   deleteChatRoom,
   type ChatMessageResDto,
@@ -43,8 +41,10 @@ function toUiMessage(dto: ChatMessageResDto | ChatMessage): ChatMessageUI {
 
   return {
     id: String((dto as unknown as { id: number | string }).id),
+    userId: userId != null ? String(userId) : undefined,
     author: nickname ?? (userId != null ? `User ${String(userId)}` : "Unknown"),
     content: (dto as unknown as { content: string }).content,
+    mediaUrls: (dto as unknown as { mediaUrls?: string[] }).mediaUrls,
     createdAt: (dto as unknown as { createdAt: string }).createdAt,
   };
 }
@@ -191,7 +191,12 @@ export function useAzitPageLogic() {
     markFeedbackDone,
   });
 
-  const { clipsByAzit, createMediaItems, addClipsFromMedia, initAzitClips } = useAzitMedia(mockClipsByAzit);
+  const {
+    clipsByAzit,
+    addClipsFromMedia,
+    replaceClipsFromMedia,
+    initAzitClips,
+  } = useAzitMedia({});
 
   const {
     chatRooms,
@@ -225,6 +230,21 @@ export function useAzitPageLogic() {
     roomId: selectedChatRoomId ?? undefined,
     onMessage: (msg) => {
       appendMessageToRoom(msg.chatRoomId, toUiMessage(msg));
+
+      if (msg.mediaUrls && msg.mediaUrls.length > 0) {
+        const isMine = String(msg.userId) === String(currentUserId);
+        if (!isMine) {
+          const roomName =
+            chatRooms.find((room) => room.id === msg.chatRoomId)?.roomName ??
+            selectedChatRoomName ??
+            "자유 대화";
+          const mediaItems = msg.mediaUrls.map((url) => ({
+            url,
+            type: url.match(/\.(mp4|mov|webm)(\?|$)/i) ? ("video" as const) : ("image" as const),
+          }));
+          addClipsFromMedia(currentAzitId, roomName, mediaItems);
+        }
+      }
     },
     onError: (err) => {
       setSocketUiError(err);
@@ -303,7 +323,8 @@ export function useAzitPageLogic() {
 
   const currentAzit = azits.find((a) => a.id === currentAzitId) ?? azits[0];
   const currentMembers = membersByAzit[currentAzitId] ?? [];
-  const currentClips = clipsByAzit[currentAzitId] ?? [];
+  const currentClips =
+    clipsByAzit[currentAzitId]?.[selectedChatRoomName || "자유 대화"] ?? [];
 
   const reloadChatRooms = React.useCallback(async () => {
     if (!accessToken) return;
@@ -349,21 +370,69 @@ export function useAzitPageLogic() {
           roomId: selectedChatRoomId,
         });
         replaceMessagesForRoom(selectedChatRoomId, list.messages.map(toUiMessage));
+
+        const roomName = selectedChatRoomName || "자유 대화";
+        const mediaItems = list.messages
+          .filter((msg) => Array.isArray(msg.mediaUrls) && msg.mediaUrls.length > 0)
+          .sort(
+            (a, b) =>
+              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          )
+          .flatMap((msg) => {
+            const dateLabel = new Date(msg.createdAt).toLocaleDateString("ko-KR");
+            return (msg.mediaUrls ?? []).map((url, idx) => ({
+              id: `${msg.id}-${idx}`,
+              url,
+              type: url.match(/\.(mp4|mov|webm)(\?|$)/i)
+                ? ("video" as const)
+                : ("image" as const),
+              dateLabel,
+            }));
+          });
+
+        replaceClipsFromMedia(currentAzitId, roomName, mediaItems);
       } catch {
         // ignore
       }
     })();
-  }, [apiBaseUrl, accessToken, selectedChatRoomId, replaceMessagesForRoom]);
+  }, [
+    apiBaseUrl,
+    accessToken,
+    currentAzitId,
+    replaceClipsFromMedia,
+    replaceMessagesForRoom,
+    selectedChatRoomId,
+    selectedChatRoomName,
+  ]);
 
   const onSendMessage = React.useCallback(
     async (roomId: number, content: string, files: File[]) => {
       const text = content.trim();
-      const media = createMediaItems(files);
-      if (!text && media.length === 0) return;
-      if (media.length > 0) addClipsFromMedia(currentAzitId, media);
-      await sendSocketMessage(roomId, text);
+      const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+      const rejected = files.filter((file) => !file.type.startsWith("image/"));
+      if (rejected.length > 0) {
+        alert("이미지 파일만 전송할 수 있어요.");
+      }
+
+      if (!text && imageFiles.length === 0) return;
+      if (!accessToken) return;
+
+      let mediaUrls: string[] = [];
+      if (imageFiles.length > 0) {
+        mediaUrls = await Promise.all(
+          imageFiles.map((file) =>
+            uploadChatImage({ apiBaseUrl, accessToken, roomId, file }).then((res) => res.mediaUrl)
+          )
+        );
+        if (mediaUrls.length > 0) {
+          const mediaItems = mediaUrls.map((url) => ({ url, type: "image" as const }));
+          addClipsFromMedia(currentAzitId, selectedChatRoomName ?? "자유 대화", mediaItems);
+        }
+      }
+
+      await sendSocketMessage(roomId, text, mediaUrls.length > 0 ? mediaUrls : undefined);
     },
-    [addClipsFromMedia, createMediaItems, currentAzitId, sendSocketMessage]
+    [accessToken, addClipsFromMedia, apiBaseUrl, currentAzitId, selectedChatRoomName, sendSocketMessage]
   );
 
   const onCreateChatRoom = React.useCallback(

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -28,6 +28,8 @@ import {
   getChatRoomsByAzit,
   getChatMessages,
   createChatRoomByAzit,
+  updateChatRoom,
+  deleteChatRoom,
   type ChatMessageResDto,
 } from "@/features/team/api/chatApi";
 
@@ -387,6 +389,78 @@ export function useAzitPageLogic() {
     [accessToken, apiBaseUrl, currentAzitId, reloadChatRooms, setSelectedChatRoom]
   );
 
+  const onRenameChatRoom = React.useCallback(
+    async (roomId: number, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed) return;
+      const prevRooms = chatRooms;
+      setChatRoomsFromServer(
+        prevRooms.map((room) => (room.id === roomId ? { ...room, roomName: trimmed } : room))
+      );
+      if (!accessToken) return;
+      try {
+        await updateChatRoom({ apiBaseUrl, accessToken, roomId, name: trimmed });
+      } catch (err) {
+        console.error("채팅방 이름 수정 실패:", err);
+        await reloadChatRooms();
+      }
+    },
+    [accessToken, apiBaseUrl, chatRooms, reloadChatRooms, setChatRoomsFromServer]
+  );
+
+  const onDeleteChatRoom = React.useCallback(
+    async (roomId: number) => {
+      const prevRooms = chatRooms;
+      setChatRoomsFromServer(prevRooms.filter((room) => room.id !== roomId));
+      if (!accessToken) return;
+      try {
+        await deleteChatRoom({ apiBaseUrl, accessToken, roomId });
+      } catch (err) {
+        console.error("채팅방 삭제 실패:", err);
+        await reloadChatRooms();
+      }
+    },
+    [accessToken, apiBaseUrl, chatRooms, reloadChatRooms, setChatRoomsFromServer]
+  );
+
+  const onRenameVoiceRoom = React.useCallback(
+    async (roomId: string, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed) return;
+      const prevRooms = voiceRooms;
+      setVoiceRoomsFromServer(
+        prevRooms.map((room) => (room.id === roomId ? { ...room, name: trimmed } : room))
+      );
+      if (!accessToken) return;
+      const numericRoomId = Number(roomId);
+      if (Number.isNaN(numericRoomId)) return;
+      try {
+        await updateChatRoom({ apiBaseUrl, accessToken, roomId: numericRoomId, name: trimmed });
+      } catch (err) {
+        console.error("음성 채팅방 이름 수정 실패:", err);
+        await reloadChatRooms();
+      }
+    },
+    [accessToken, apiBaseUrl, reloadChatRooms, setVoiceRoomsFromServer, voiceRooms]
+  );
+
+  const onDeleteVoiceRoom = React.useCallback(
+    async (roomId: string) => {
+      const prevRooms = voiceRooms;
+      setVoiceRoomsFromServer(prevRooms.filter((room) => room.id !== roomId));
+      if (!accessToken) return;
+      const numericRoomId = Number(roomId);
+      if (Number.isNaN(numericRoomId)) return;
+      try {
+        await deleteChatRoom({ apiBaseUrl, accessToken, roomId: numericRoomId });
+      } catch (err) {
+        console.error("음성 채팅방 삭제 실패:", err);
+        await reloadChatRooms();
+      }
+    },
+    [accessToken, apiBaseUrl, reloadChatRooms, setVoiceRoomsFromServer, voiceRooms]
+  );
+
   React.useEffect(() => {
     return () => {
       azitIconUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
@@ -508,6 +582,10 @@ export function useAzitPageLogic() {
       setSelectedChatRoom,
       onSendMessage,
       onCreateChatRoom,
+      onRenameChatRoom,
+      onDeleteChatRoom,
+      onRenameVoiceRoom,
+      onDeleteVoiceRoom,
       handleStatusChange,
       addSchedule,
       openFeedbackModal,

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -9,8 +9,6 @@ import { login } from "@/services/authApi";
 
 import {
   mockMembers,
-  mockMembersByAzit,
-  mockSchedulesByAzit,
   mockClipsByAzit,
 } from "@/features/team/data/mockTeamData";
 
@@ -129,7 +127,7 @@ export function useAzitPageLogic() {
     handleStatusChange,
     addSchedule,
     markFeedbackDone,
-  } = useAzitSchedules(currentUserId, mockSchedulesByAzit, mockMembersByAzit, currentUser);
+  } = useAzitSchedules(currentUserId, currentUser, accessToken);
 
   React.useEffect(() => {
     if (!accessToken) return;

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -8,12 +8,13 @@ import { useAuthStore } from "@/store/authStore";
 import { login } from "@/services/authApi";
 
 import {
-  MOCK_MY_AZITS,
   mockMembers,
   mockMembersByAzit,
   mockSchedulesByAzit,
   mockClipsByAzit,
 } from "@/features/team/data/mockTeamData";
+
+import { getAzits } from "@/features/team/api/azitApi";
 
 import { useAzitSchedules } from "@/features/team/hooks/useAzitSchedules";
 import { useAzitFeedback } from "@/features/team/hooks/useAzitFeedback";
@@ -52,7 +53,7 @@ export function useAzitPageLogic() {
   const routeState = location.state as { azitId?: number } | null;
 
   const [scheduleAnchorEl, setScheduleAnchorEl] = React.useState<HTMLElement | null>(null);
-  const [azits, setAzits] = React.useState(MOCK_MY_AZITS);
+  const [azits, setAzits] = React.useState([]);
   const azitIconUrlsRef = React.useRef<string[]>([]);
   
   // Auth Store 정보 가져오기
@@ -127,6 +128,27 @@ export function useAzitPageLogic() {
     addSchedule,
     markFeedbackDone,
   } = useAzitSchedules(currentUserId, mockSchedulesByAzit, mockMembersByAzit, currentUser);
+
+  React.useEffect(() => {
+    if (!accessToken) return;
+    let alive = true;
+    (async () => {
+      try {
+        const list = await getAzits();
+        if (!alive) return;
+        setAzits(list);
+        if (list.length > 0) {
+          const exists = list.some((a) => a.id === currentAzitId);
+          if (!exists) setCurrentAzitId(list[0].id);
+        }
+      } catch (err) {
+        console.error("아지트 목록 조회 실패:", err);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [accessToken, currentAzitId, setCurrentAzitId]);
 
   const {
     feedbackModal,

--- a/Playproof/src/features/team/hooks/useAzitPageLogic.ts
+++ b/Playproof/src/features/team/hooks/useAzitPageLogic.ts
@@ -12,7 +12,7 @@ import {
   mockClipsByAzit,
 } from "@/features/team/data/mockTeamData";
 
-import { getAzits } from "@/features/team/api/azitApi";
+import { getAzits, updateAzit } from "@/features/team/api/azitApi";
 import { getAzitMembers, mapAzitMembersToUsers } from "@/features/team/api/azitMemberApi";
 
 import { useAzitSchedules } from "@/features/team/hooks/useAzitSchedules";
@@ -409,6 +409,75 @@ export function useAzitPageLogic() {
     [azits, initAzitClips, initAzitRooms, setCurrentAzitId]
   );
 
+  const updateAzitName = React.useCallback(
+    async (azitId: number, nextName: string) => {
+      const trimmed = nextName.trim();
+      if (!trimmed) return;
+      try {
+        const updated = await updateAzit(azitId, { azit_name: trimmed });
+        setAzits((prev) =>
+          prev.map((azit) =>
+            azit.id === azitId
+              ? { ...azit, name: updated.azit_name }
+              : azit
+          )
+        );
+      } catch (err) {
+        console.error("아지트 이름 수정 실패:", err);
+      }
+    },
+    []
+  );
+
+  const updateAzitIcon = React.useCallback(
+    async (azitId: number, file: File) => {
+      if (!file) return;
+      try {
+        const updated = await updateAzit(azitId, { azit_icon: file });
+        setAzits((prev) =>
+          prev.map((azit) =>
+            azit.id === azitId
+              ? {
+                  ...azit,
+                  icon: updated.azit_icon_url ?? azit.icon,
+                }
+              : azit
+          )
+        );
+      } catch (err) {
+        console.error("아지트 아이콘 수정 실패:", err);
+      }
+    },
+    []
+  );
+
+  const updateAzitSettings = React.useCallback(
+    async (azitId: number, payload: { name?: string; file?: File | null }) => {
+      const trimmedName = payload.name?.trim();
+      if (!trimmedName && !payload.file) return;
+      try {
+        const updated = await updateAzit(azitId, {
+          azit_name: trimmedName ?? undefined,
+          azit_icon: payload.file ?? undefined,
+        });
+        setAzits((prev) =>
+          prev.map((azit) =>
+            azit.id === azitId
+              ? {
+                  ...azit,
+                  name: updated.azit_name ?? azit.name,
+                  icon: updated.azit_icon_url ?? azit.icon,
+                }
+              : azit
+          )
+        );
+      } catch (err) {
+        console.error("아지트 설정 변경 실패:", err);
+      }
+    },
+    []
+  );
+
   return {
     state: {
       azits,
@@ -448,6 +517,9 @@ export function useAzitPageLogic() {
       joinVoiceRoom,
       toggleMyMic,
       addAzit,
+      updateAzitName,
+      updateAzitIcon,
+      updateAzitSettings,
     },
   };
 }

--- a/Playproof/src/features/team/hooks/useAzitRooms.ts
+++ b/Playproof/src/features/team/hooks/useAzitRooms.ts
@@ -10,8 +10,10 @@ export type ChatRoomSummary = {
 
 export type ChatMessageUI = {
   id: string;
+  userId?: string;
   author: string;
   content: string;
+  mediaUrls?: string[];
   createdAt: string;
 };
 

--- a/Playproof/src/features/team/hooks/useAzitRooms.ts
+++ b/Playproof/src/features/team/hooks/useAzitRooms.ts
@@ -114,9 +114,12 @@ export const useAzitRooms = (currentAzitId: number, currentUser: User) => {
 
   const replaceMessagesForRoom = React.useCallback(
     (roomId: number, next: ChatMessageUI[]) => {
+      const sorted = [...next].sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      );
       setMessagesByAzit((prev) => {
         const byAzit = prev[currentAzitId] ?? {};
-        return { ...prev, [currentAzitId]: { ...byAzit, [roomId]: next } };
+        return { ...prev, [currentAzitId]: { ...byAzit, [roomId]: sorted } };
       });
     },
     [currentAzitId]
@@ -127,7 +130,7 @@ export const useAzitRooms = (currentAzitId: number, currentUser: User) => {
       setMessagesByAzit((prev) => {
         const byAzit = prev[currentAzitId] ?? {};
         const list = byAzit[roomId] ?? [];
-        return { ...prev, [currentAzitId]: { ...byAzit, [roomId]: [msg, ...list] } };
+        return { ...prev, [currentAzitId]: { ...byAzit, [roomId]: [...list, msg] } };
       });
     },
     [currentAzitId]
@@ -188,6 +191,19 @@ export const useAzitRooms = (currentAzitId: number, currentUser: User) => {
     [currentAzitId, currentUser, myVoiceRoomIdByAzit]
   );
 
+  const leaveVoiceRoom = React.useCallback(() => {
+    const me = currentUser;
+    setVoiceRoomsByAzit((prev) => {
+      const rooms = prev[currentAzitId] ?? createDefaultVoiceRooms();
+      const nextRooms = rooms.map((room) => ({
+        ...room,
+        users: room.users.filter((m) => String(m.user.id) !== String(me.id)),
+      }));
+      return { ...prev, [currentAzitId]: nextRooms };
+    });
+    setMyVoiceRoomIdByAzit((prev) => ({ ...prev, [currentAzitId]: null }));
+  }, [currentAzitId, currentUser]);
+
   const initAzitRooms = React.useCallback((azitId: number) => {
     setChatRoomsByAzit((prev) => ({ ...prev, [azitId]: [] }));
     setSelectedChatRoomIdByAzit((prev) => ({ ...prev, [azitId]: null }));
@@ -210,6 +226,7 @@ export const useAzitRooms = (currentAzitId: number, currentUser: User) => {
     voiceRooms,
     myVoiceRoomId,
     joinVoiceRoom,
+    leaveVoiceRoom,
     toggleMyMic,
 
     initAzitRooms,

--- a/Playproof/src/features/team/hooks/useAzitSchedules.ts
+++ b/Playproof/src/features/team/hooks/useAzitSchedules.ts
@@ -7,6 +7,7 @@ import type { ScheduleCreatePayload } from "@/features/team/hooks/useScheduleCre
 import {
   createAzitSchedule,
   getAzitSchedules,
+  getAzitScheduleMyParticipationStatus,
   joinAzitScheduleParticipant,
   updateAzitScheduleParticipantStatus,
   type AzitScheduleDetailResDto,
@@ -101,10 +102,41 @@ export function useAzitSchedules(
       try {
         const res = await getAzitSchedules({ azitId: currentAzitId, size: 20 });
         if (!alive) return;
-        const list = res.schedules.map((dto) =>
+        const baseList = res.schedules.map((dto) =>
           mapScheduleDtoToUi(dto, currentUserId, currentUser)
         );
-        setSchedules(list);
+
+        const enriched = await Promise.all(
+          baseList.map(async (schedule) => {
+            const hasMe = schedule.participants.some(
+              (p) => coerceUserId(p.user?.id ?? "") === coerceUserId(currentUserId)
+            );
+            if (hasMe || !currentUserId) return schedule;
+
+            try {
+              const status = await getAzitScheduleMyParticipationStatus({
+                azitId: currentAzitId,
+                scheduleId: schedule.id,
+              });
+              if (!status) return schedule;
+
+              const normalizedStatus = status === "CANCELLED" ? "DECLINE" : status;
+              if (normalizedStatus === "JOIN") return schedule;
+
+              return {
+                ...schedule,
+                participants: [
+                  ...schedule.participants,
+                  { user: currentUser, status: normalizedStatus },
+                ],
+              };
+            } catch {
+              return schedule;
+            }
+          })
+        );
+
+        setSchedules(enriched);
       } catch (err) {
         if (!alive) return;
         console.error("스케줄 목록 로드 실패:", err);

--- a/Playproof/src/features/team/hooks/useAzitSchedules.ts
+++ b/Playproof/src/features/team/hooks/useAzitSchedules.ts
@@ -3,101 +3,196 @@
 import React from "react";
 import type { Schedule } from "@/features/team/types";
 import type { User } from "@/types";
-
-type TimeSelection = {
-  ampm: "AM" | "PM";
-  hour: number;
-  minute: number;
-};
-
-type CreateSchedulePayload = {
-  title: string;
-  recruitCount: number;
-  gameDate?: Date;
-  gameStartTime: TimeSelection;
-};
+import type { ScheduleCreatePayload } from "@/features/team/hooks/useScheduleCreateState";
+import {
+  createAzitSchedule,
+  getAzitSchedules,
+  joinAzitScheduleParticipant,
+  updateAzitScheduleParticipantStatus,
+  type AzitScheduleDetailResDto,
+} from "@/features/team/api/azitScheduleApi";
 
 const coerceUserId = (value: string | number) => String(value);
 
+const toLocalDateTimeString = (date: Date) => {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mi = String(date.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:00`;
+};
+
+const applyTimeToDate = (
+  baseDate: Date,
+  time: ScheduleCreatePayload["gameStartTime"]
+) => {
+  const date = new Date(baseDate);
+  const hour = time.hour % 12 + (time.ampm === "PM" ? 12 : 0);
+  date.setHours(hour, time.minute, 0, 0);
+  return date;
+};
+
+const mapScheduleDtoToUi = (
+  dto: AzitScheduleDetailResDto,
+  currentUserId: string,
+  currentUser: User
+): Schedule => {
+  const gameStart = new Date(dto.game_start_at);
+  const dateStr = `${String(gameStart.getMonth() + 1).padStart(2, "0")}.${String(
+    gameStart.getDate()
+  ).padStart(2, "0")}`;
+  const timeStr = gameStart.toLocaleTimeString("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const participants = (dto.participants ?? []).map((p) => ({
+    user: {
+      id: String(p.member_id),
+      nickname: p.nickname ?? "Unknown",
+      avatarUrl: p.avatar_url ?? "",
+      isOnline: true,
+    },
+    status: "JOIN" as const,
+  }));
+
+  const hasMe = participants.some(
+    (p) => coerceUserId(p.user?.id ?? "") === coerceUserId(currentUserId)
+  );
+  if (dto.is_participated && !hasMe) {
+    participants.push({ user: currentUser, status: "JOIN" });
+  }
+
+  const hostId =
+    (dto as unknown as { host_id?: number; hostId?: number }).host_id ??
+    (dto as unknown as { host_id?: number; hostId?: number }).hostId ??
+    (dto.participants?.[0]?.member_id ?? "");
+
+  return {
+    id: String(dto.schedule_id),
+    title: dto.title,
+    dateStr,
+    timeStr,
+    fullDate: gameStart,
+    hostId: String(hostId ?? ""),
+    maxMembers: dto.max_participants,
+    participants,
+    isFeedbackDone: false,
+  };
+};
+
 export function useAzitSchedules(
   currentUserId: string,
-  schedulesByAzit: Record<number, Schedule[]>,
-  membersByAzit: Record<number, User[]>,
-  currentUser: User
+  currentUser: User,
+  accessToken?: string | null
 ) {
   const [currentAzitId, setCurrentAzitId] = React.useState<number>(1);
   const [schedules, setSchedules] = React.useState<Schedule[]>([]);
 
   React.useEffect(() => {
-    const initialSchedules = schedulesByAzit[currentAzitId] ?? [];
-    setSchedules(initialSchedules);
-  }, [currentAzitId, schedulesByAzit]);
+    let alive = true;
+    const load = async () => {
+      if (!accessToken) {
+        setSchedules([]);
+        return;
+      }
+      try {
+        const res = await getAzitSchedules({ azitId: currentAzitId, size: 20 });
+        if (!alive) return;
+        const list = res.schedules.map((dto) =>
+          mapScheduleDtoToUi(dto, currentUserId, currentUser)
+        );
+        setSchedules(list);
+      } catch (err) {
+        if (!alive) return;
+        console.error("스케줄 목록 로드 실패:", err);
+        setSchedules([]);
+      }
+    };
+    load();
+    return () => {
+      alive = false;
+    };
+  }, [accessToken, currentAzitId, currentUser, currentUserId]);
 
   const handleStatusChange = React.useCallback(
-    (scheduleId: string, newStatus: "JOIN" | "DECLINE") => {
-      setSchedules((prevSchedules) =>
-        prevSchedules.map((sch) => {
+    async (scheduleId: string, newStatus: "JOIN" | "DECLINE") => {
+      const prevSchedules = schedules;
+      setSchedules((prev) =>
+        prev.map((sch) => {
           if (sch.id !== scheduleId) return sch;
-
-          const myIndex = sch.participants.findIndex(
+          const participants = [...sch.participants];
+          const myIndex = participants.findIndex(
             (p) => coerceUserId(p.user?.id ?? "") === coerceUserId(currentUserId)
           );
-
-          const nextParticipants = [...sch.participants];
-
           if (myIndex !== -1) {
-            nextParticipants[myIndex] = {
-              ...nextParticipants[myIndex],
-              status: newStatus,
-            };
+            participants[myIndex] = { ...participants[myIndex], status: newStatus };
           } else {
-            const members = membersByAzit[currentAzitId] ?? [];
-            const me = members.find(
-              (member) => coerceUserId(member.id) === coerceUserId(currentUserId)
-            );
-            if (me) {
-              nextParticipants.push({ user: me, status: newStatus });
-            }
+            participants.push({ user: currentUser, status: newStatus });
           }
-
-          return { ...sch, participants: nextParticipants };
+          return { ...sch, participants };
         })
       );
+
+      if (!accessToken) return;
+      try {
+        if (newStatus === "JOIN") {
+          await joinAzitScheduleParticipant({ azitId: currentAzitId, scheduleId });
+        } else {
+          await updateAzitScheduleParticipantStatus({
+            azitId: currentAzitId,
+            scheduleId,
+            status: newStatus,
+          });
+        }
+      } catch (err) {
+        console.error("스케줄 참여 상태 변경 실패:", err);
+        setSchedules(prevSchedules);
+      }
     },
-    [currentUserId, currentAzitId, membersByAzit]
+    [accessToken, currentAzitId, currentUser, currentUserId, schedules]
   );
 
   const addSchedule = React.useCallback(
-    (data: CreateSchedulePayload) => {
-      if (!data.gameDate) return;
-      const date = new Date(data.gameDate);
-      const hour = data.gameStartTime.hour % 12 + (data.gameStartTime.ampm === "PM" ? 12 : 0);
-      date.setHours(hour, data.gameStartTime.minute, 0, 0);
+    async (data: ScheduleCreatePayload) => {
+      if (!data.gameDate || !data.recruitRange?.from) return;
 
-      const timeStr = date.toLocaleTimeString("ko-KR", {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-      });
-      const dateStr = `${String(date.getMonth() + 1).padStart(2, "0")}.${String(
-        date.getDate()
-      ).padStart(2, "0")}`;
+      const gameStartDate = applyTimeToDate(data.gameDate, data.gameStartTime);
+      const gameEndDate = applyTimeToDate(data.gameDate, data.gameEndTime);
+      const recruitEndBase = data.recruitRange.to ?? data.recruitRange.from;
+      const recruitEndDate = applyTimeToDate(recruitEndBase, data.recruitEndTime);
 
-      const newSchedule: Schedule = {
-        id: String(Date.now()),
-        title: data.title.trim(),
-        dateStr,
-        timeStr,
-        fullDate: date,
-        hostId: String(currentUserId),
-        maxMembers: data.recruitCount,
-        participants: [{ user: currentUser, status: "JOIN" }],
-        isFeedbackDone: false,
-      };
+      if (gameEndDate.getTime() <= gameStartDate.getTime()) {
+        gameEndDate.setDate(gameEndDate.getDate() + 1);
+      }
+      if (recruitEndDate.getTime() >= gameStartDate.getTime()) {
+        recruitEndDate.setTime(gameStartDate.getTime() - 60_000);
+      }
 
-      setSchedules((prev) => [newSchedule, ...prev]);
+      if (!accessToken) return;
+      try {
+        await createAzitSchedule({
+          azitId: currentAzitId,
+          payload: {
+            title: data.title.trim(),
+            max_participants: Math.max(2, data.recruitCount),
+            game_start_at: toLocalDateTimeString(gameStartDate),
+            game_end_at: toLocalDateTimeString(gameEndDate),
+            recruitment_end_at: toLocalDateTimeString(recruitEndDate),
+          },
+        });
+        const res = await getAzitSchedules({ azitId: currentAzitId, size: 20 });
+        const list = res.schedules.map((dto) =>
+          mapScheduleDtoToUi(dto, currentUserId, currentUser)
+        );
+        setSchedules(list);
+      } catch (err) {
+        console.error("스케줄 생성 실패:", err);
+      }
     },
-    [currentUser, currentUserId]
+    [accessToken, currentAzitId, currentUser, currentUserId]
   );
 
   const markFeedbackDone = React.useCallback((scheduleId: string) => {
@@ -110,7 +205,6 @@ export function useAzitSchedules(
     currentAzitId,
     setCurrentAzitId,
     schedules,
-    setSchedules,
     handleStatusChange,
     addSchedule,
     markFeedbackDone,

--- a/Playproof/src/features/team/hooks/useAzitSocket.ts
+++ b/Playproof/src/features/team/hooks/useAzitSocket.ts
@@ -43,6 +43,7 @@ export interface ChatMessage {
   userId: number;
   nickname?: string | null;
   content: string;
+  mediaUrls?: string[];
   createdAt: string;
 }
 
@@ -230,9 +231,10 @@ export const useAzitSocket = (params: {
 
   const sendMessage = async (
     targetRoomId: number,
-    content: string
+    content: string,
+    mediaUrls?: string[]
   ): Promise<ChatMessage> => {
-    return emitWithAck("sendMessage", { roomId: targetRoomId, content });
+    return emitWithAck("sendMessage", { roomId: targetRoomId, content, mediaUrls });
   };
 
   const voiceJoin = async (targetRoomId: number) => {

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -150,6 +150,7 @@ export const AzitPageView = () => {
             roomName={selectedChatRoomName}
             messages={messages}
             onSendMessage={actions.onSendMessage}
+            currentUserId={currentUserId}
             currentUserName={currentUser.nickname}
           />
 

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -187,9 +187,8 @@ export const AzitPageView = () => {
         open={isAzitSettingsOpen}
         onClose={() => setIsAzitSettingsOpen(false)}
         profileUrl={currentAzit?.icon}
-        onUpdateProfile={(url) => actions.updateAzitIcon(currentAzitId, url)}
         initialName={currentAzit?.name ?? ""}
-        onUpdateName={(nextName) => actions.updateAzitName(currentAzitId, nextName)}
+        onSave={({ name, file }) => actions.updateAzitSettings(currentAzitId, { name, file })}
       />
 
       <FeedbackModal

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -138,10 +138,10 @@ export const AzitPageView = () => {
             textRooms={chatRooms}
             // ✅ 수정: actions.onCreateChatRoom을 그대로 전달 (PageLogic에서 처리)
             onCreateChatRoom={actions.onCreateChatRoom}
-            onRenameVoiceRoom={() => {}}
-            onDeleteVoiceRoom={() => {}}
-            onRenameChatRoom={() => {}}
-            onDeleteChatRoom={() => {}}
+            onRenameVoiceRoom={actions.onRenameVoiceRoom}
+            onDeleteVoiceRoom={actions.onDeleteVoiceRoom}
+            onRenameChatRoom={actions.onRenameChatRoom}
+            onDeleteChatRoom={actions.onDeleteChatRoom}
           />
 
           <MainPanel

--- a/Playproof/src/features/team/pages/AzitPageView.tsx
+++ b/Playproof/src/features/team/pages/AzitPageView.tsx
@@ -90,12 +90,12 @@ export const AzitPageView = () => {
               </button>
 
               <h1 className="text-xl font-extrabold text-gray-900 tracking-tight">
-                {currentAzit.name}
+                {currentAzit?.name ?? "아지트"}
               </h1>
 
               <div className="flex items-center gap-1 text-gray-500 font-bold mt-0.5">
                 <Users className="w-4 h-4" />
-                <span className="text-sm">{currentAzit.memberCount}</span>
+                <span className="text-sm">{currentAzit?.memberCount ?? 0}</span>
               </div>
 
               <span
@@ -186,9 +186,9 @@ export const AzitPageView = () => {
       <AzitSettingsModal
         open={isAzitSettingsOpen}
         onClose={() => setIsAzitSettingsOpen(false)}
-        profileUrl={currentAzit.icon}
+        profileUrl={currentAzit?.icon}
         onUpdateProfile={(url) => actions.updateAzitIcon(currentAzitId, url)}
-        initialName={currentAzit.name}
+        initialName={currentAzit?.name ?? ""}
         onUpdateName={(nextName) => actions.updateAzitName(currentAzitId, nextName)}
       />
 


### PR DESCRIPTION
# [Feat] 아지트 API 연동 완료 (일정/멤버/관리) 및 채팅 미디어 기능 구현

## 개요
아지트(Azit) 페이지의 핵심 기능인 **아지트 관리, 일정(Schedule), 멤버 조회, 음성/텍스트 채팅방 관리** API 연동을 완료했습니다.
또한, 채팅 내 **이미지 전송 기능**과 **최근 클립(미디어 갤러리)** 기능을 구현하여 멀티미디어 소통이 가능하도록 업데이트했습니다.

## 주요 작업 내용

### 1. 아지트 관리 및 멤버 (Azit & Member)
- **아지트 CRUD**: 아지트 생성, 조회, 수정 로직 연동 완료.
- **멤버 관리**: 아지트 내 참여 멤버 리스트 조회 기능 구현.

### 2. 일정 관리 (Schedule)
- **일정 기능**: 스케줄 생성 및 조회 API 연동.
- **상태 관리**: 스케줄 초대 수락/거절(RSVP) 액션 연동.

### 3. 채팅방 및 음성채팅 관리 (Rooms)
- **텍스트 채팅**: 채팅방 생성, 수정, 삭제 기능 구현.
- **음성 채팅**: 음성 채널 생성, 수정, 삭제 및 **나가기** 기능 구현.

### 4. 채팅 메시지 및 미디어 (Chat & Media)
- **이미지 전송**: 채팅방 내 이미지 업로드 및 전송 로직 구현.
- **UI/UX 개선**:
  - **정렬**: 채팅 메시지 정렬 기준 변경 및 내/상대방 메시지 좌우 정렬 보정.
  - **스크롤**: 이미지 전송 시 최하단으로 자동 스크롤 이동.
- **최근 클립 (Media Gallery)**:
  - 전송된 이미지를 **최근 클립**으로 저장.
  - 우측 패널에 **최근 3개 미리보기** 노출.
  - **전체보기 갤러리** 모달 및 기능 구현.
  - 기존 Mock 데이터 제거 및 실제 메시지 기반 데이터 구성.

---

## 수정 및 보완 필요 사항 (Known Issues)

아래 항목들은 현재 구현은 되어 있으나, **추가 테스트 또는 백엔드/기능 연동이 필요한 미완료 사항**입니다.

- [ ] **하이라이트 공유 연동 미완료**: 공유 버튼 UI는 있으나 하이라이트 글쓰기로 넘어가는 로직이 연결되지 않음.
- [ ] **실시간 채팅 양방향 통신 테스트 미완료**: 단방향 전송은 확인했으나, 실제 소켓 환경에서의 수신/동기화 테스트 필요.
- [ ] **실시간 음성채팅 양방향 통신 테스트 미완료**: 마이크 권한은 확인했으나, 실제 음성 패킷 송수신 테스트 필요.
- [ ] **S3 CORS 문제 미해결**: 이미지 업로드 및 외부 가져오기 시 CORS 정책으로 인한 에러 발생 (백엔드 설정 대기 중).

---

## 테스트 결과
- [x] 아지트 생성 후 스케줄 등록 및 조회, 멤버 리스트 표시 정상 동작 확인.
- [x] 채팅방 및 음성채팅방 생성/수정/삭제/나가기 동작 확인.
- [x] 채팅창에 이미지 전송 시 말풍선 표시 및 우측 클립 영역에 즉시 반영 확인.
- [x] 클립 갤러리 '전체보기' 클릭 시 모달 정상 작동 확인.

---

## 관련 이슈
- Closes #76 